### PR TITLE
Single process with no children

### DIFF
--- a/bot-lax-listener.sh
+++ b/bot-lax-listener.sh
@@ -8,4 +8,4 @@ set -e
 # the 'ci' in 'lax--ci'
 instance_id=$1
 
-python src/adaptor.py --type sqs --instance "$instance_id"
+exec python src/adaptor.py --type sqs --instance "$instance_id"

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -e # everything must pass
 
 # ensure the venv is installed
-. ./install.sh &> /dev/null
+. ./install.sh
 
 # activate venv
 . ./venv/bin/activate


### PR DESCRIPTION
Executing Python from a shell script creates two processes:
```
17553 ?        Ss     0:00 /bin/bash ./bot-lax-listener.sh end2end 1
17598 ?        S      0:00  \_ python src/adaptor.py --type sqs
```
Using `exec` replaces the shell with the new process:
```
17598 ?        S      0:00  python src/adaptor.py --type sqs
```
so that when Upstart restarts it, this single process is terminated and
created again rather than leaving around orphans.