### PR TITLE
Fixing graceful shutdown

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -276,10 +276,6 @@ def do(incoming, outgoing):
     except KeyboardInterrupt:
         LOG.warn("stopping abruptly due to KeyboardInterrupt")
 
-    finally:
-        incoming.close()
-        outgoing.close()
-
     LOG.info("graceful shutdown")
 
 def bootstrap():

--- a/src/fs_adaptor.py
+++ b/src/fs_adaptor.py
@@ -36,9 +36,6 @@ class IncomingQueue(object):
             utils.validate_request(request)
             yield request
 
-    def close(self):
-        pass
-
 class OutgoingQueue(object):
     def __init__(self):
         self.valids = []
@@ -68,6 +65,3 @@ class OutgoingQueue(object):
         print 'valid ::', self.valids
         print 'invalid ::', self.invalids
         print 'errors ::', self.errors
-
-    def close(self):
-        pass

--- a/src/sqs_adaptor.py
+++ b/src/sqs_adaptor.py
@@ -26,21 +26,25 @@ def poll(queue_obj):
         message.delete()
 
 class IncomingQueue(object):
-    def __init__(self, queue_name):
+    def __init__(self, queue_name, flag=None):
         self.queue = conn().get_queue_by_name(QueueName=queue_name)
+        self.flag = flag
 
     def __iter__(self):
         """an infinite poll on the given queue object.
         blocks for 20 seconds before connection is dropped and re-established"""
         while True:
-            messages = []
-            while not messages:
-                messages = self.queue.receive_messages(
-                    MaxNumberOfMessages=1,
-                    VisibilityTimeout=60, # time allowed to call delete, can be increased
-                    WaitTimeSeconds=20 # maximum setting for long polling
-                )
-            LOG.debug("processing sqs message")
+            if self.flag.should_stop:
+                break
+            messages = self.queue.receive_messages(
+                MaxNumberOfMessages=1,
+                VisibilityTimeout=60, # time allowed to call delete, can be increased
+                WaitTimeSeconds=20 # maximum setting for long polling
+            )
+            if not messages:
+                continue
+
+            LOG.debug("processing message")
             message = messages[0]
             yield message.body
             message.delete()

--- a/src/sqs_adaptor.py
+++ b/src/sqs_adaptor.py
@@ -49,10 +49,6 @@ class IncomingQueue(object):
             yield message.body
             message.delete()
 
-    def close(self):
-        # close the aws connection?
-        pass
-
 class OutgoingQueue(object):
     def __init__(self, queue_name):
         self.queue = conn().get_queue_by_name(QueueName=queue_name)
@@ -64,6 +60,3 @@ class OutgoingQueue(object):
     def error(self, string):
         "called when given an unroutable message"
         LOG.error("received unroutable message", extra={'unroutable-message': str(string)})
-
-    def close(self):
-        pass

--- a/src/tests/test_fs_adaptor.py
+++ b/src/tests/test_fs_adaptor.py
@@ -56,4 +56,3 @@ class FS(BaseCase):
         "purely for code coverage"
         out = fs_adaptor.OutgoingQueue()
         out.dump()
-        out.close()


### PR DESCRIPTION
EDIT: it turns out I already had a pull request fixing this and other problems of restarts around.

From
https://ci--alfred.elifesciences.org/job/test-elife-lax/110/consoleFull

```
      ID: bot-lax-adaptors-start
Function: cmd.run
    Name: start bot-lax-adaptors
  Result: True
 Comment: Command "start

 Started: 11:52:22.340042
Duration: 30129.05 ms
 Changes:
          ----------
          pid:
              3412
          retcode:
              0
          stderr:
          stdout:
              bot-lax-adaptors stop/waiting
```

The graceful shutdown times out after 30 seconds and the process gets
killed with `SIGKILL`.

The reason is if there are no messages (which is 99% of the time), the
inner while loop returns to polling without yielding a new value,
never exiting.

Therefore, passing the flag to the IncomingQueue allows it to check
whether it should stop, before starting any new polling. If polling
returned something, that is always processed before attempting a new
iteration.
