### PR TITLE
Feature references part 1

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -288,7 +288,7 @@ VOR.update(OrderedDict([
     ('relatedArticles', [jats('related_article'), related_article_to_related_articles]),
     ('digest', [jats('digest_json')]),
     ('body', [jats('body')]), # ha! so easy ...
-    ('references', [jats('references')]),
+    ('references', [jats('references_json')]),
     ('decisionLetter', [jats('decision_letter')]),
     ('authorResponse', [jats('author_response')]),
 ]))

--- a/src/tests/fixtures/elife-09560-v1.xml.json
+++ b/src/tests/fixtures/elife-09560-v1.xml.json
@@ -4987,30 +4987,62 @@
                         "tables": [
                             "<table><thead><tr><th/><th>Measurement definitions as in <xref ref-type=\"bibr\" rid=\"bib70\">Wood (1991)</xref></th><th><italic>P. aethiopicus</italic></th><th><italic>P. boisei</italic></th><th><italic>P. robustus</italic></th><th><italic>Au. afarensis</italic></th><th><italic>Au. africanus</italic></th><th><italic>Au. sediba</italic></th><th><italic>H. naledi</italic></th><th><italic>H. habilis</italic></th><th><italic>H. rudolfensis</italic></th><th><italic>H. erectus</italic></th><th>MP <italic>Homo</italic></th><th><italic>H. sapiens</italic></th></tr></thead><tbody><tr><td colspan=\"14\">Cranium</td></tr><tr><td>\u2003Cranial capacity</td><td>\u2013</td><td>410</td><td>485</td><td>493</td><td>457</td><td>467</td><td>420</td><td>513</td><td>610</td><td>776</td><td>865</td><td>1266</td><td>1330</td></tr><tr><td>\u2003Porion height</td><td>6</td><td>72</td><td>74</td><td>\u2013</td><td>86</td><td>70</td><td>67</td><td>81</td><td>77</td><td>90</td><td>94</td><td>101</td><td>112</td></tr><tr><td>\u2003Posterior cranial length</td><td>3</td><td>58</td><td>47</td><td>54</td><td>60</td><td>44</td><td>\u2013</td><td>65</td><td>60</td><td>70</td><td>79</td><td>99</td><td>81</td></tr><tr><td>\u2003Bi-parietal breadth</td><td>9</td><td>94</td><td>98</td><td>\u2013</td><td>90</td><td>99</td><td>100</td><td>103</td><td>107</td><td>118</td><td>129</td><td>142</td><td>132</td></tr><tr><td>\u2003Bi-temporal breadth</td><td>10</td><td>110</td><td>109</td><td>108</td><td>115</td><td>104</td><td>101</td><td>107</td><td>112</td><td>126</td><td>131</td><td>146</td><td>127</td></tr><tr><td>\u2003Closest approach of temporal lines</td><td>\u2013</td><td>crest<xref ref-type=\"table-fn\" rid=\"tblfn1\">*</xref></td><td>crest<xref ref-type=\"table-fn\" rid=\"tblfn1\">*</xref></td><td>crest<xref ref-type=\"table-fn\" rid=\"tblfn1\">*</xref></td><td>crest<xref ref-type=\"table-fn\" rid=\"tblfn1\">*</xref></td><td>21</td><td>56</td><td>52</td><td>35</td><td>51</td><td>72</td><td>101</td><td>96</td></tr><tr><td>\u2003Supraorbital height index</td><td>\u2013</td><td>46</td><td>53</td><td>50</td><td>51</td><td>60</td><td>56</td><td>56</td><td>64</td><td>59</td><td>56</td><td>62</td><td>71</td></tr><tr><td>\u2003Minimum post-orbital breadth</td><td>\u2013</td><td>62</td><td>66</td><td>70</td><td>77</td><td>67</td><td>70</td><td>68</td><td>75</td><td>78</td><td>89</td><td>96</td><td>97</td></tr><tr><td>\u2003Superior facial breadth</td><td>49</td><td>100</td><td>107</td><td>109</td><td>\u2013</td><td>95</td><td>86</td><td>86</td><td>97</td><td>113</td><td>110</td><td>124</td><td>107</td></tr><tr><td>\u2003Post-orbital constriction index<xref ref-type=\"table-fn\" rid=\"tblfn2\">\u2020</xref></td><td>\u2013</td><td>62</td><td>61</td><td>64</td><td>\u2013</td><td>69</td><td>81</td><td>79</td><td>72</td><td>74</td><td>81</td><td>80</td><td>91</td></tr><tr><td>\u2003EAM area (as an ellipse)<xref ref-type=\"table-fn\" rid=\"tblfn3\">\u2021</xref></td><td>\u2013</td><td>77</td><td>80</td><td>103</td><td>70</td><td>96</td><td>\u2013</td><td>38</td><td>76</td><td>\u2013</td><td>95</td><td>85</td><td>61</td></tr><tr><td>\u2003Root of zygomatic process origin</td><td>\u2013</td><td>P4</td><td>P4</td><td>P3 to M1</td><td>P4 to M1</td><td>P4 to M1</td><td>P4</td><td>P3 to P4</td><td>P4 to M1</td><td>P4 to M1</td><td>P4 to M1</td><td>M1</td><td>M1</td></tr><tr><td>\u2003Petromedian angle</td><td>137</td><td>50</td><td>45</td><td>50</td><td>31</td><td>33</td><td>\u2013</td><td>55</td><td>48</td><td>\u2013</td><td>52</td><td>55</td><td>46</td></tr><tr><td colspan=\"14\">Maxilloalveolar process</td></tr><tr><td>\u2003Maxilloalveolar length</td><td>87</td><td>94</td><td>78</td><td>69</td><td>67</td><td>71</td><td>63</td><td>57</td><td>65</td><td>68</td><td>66</td><td>69</td><td>55</td></tr><tr><td>\u2003Maxilloalveolar breadth</td><td>88</td><td>83</td><td>76</td><td>69</td><td>68</td><td>66</td><td>63</td><td>71</td><td>68</td><td>72</td><td>70</td><td>72</td><td>62</td></tr><tr><td>\u2003Palate breadth</td><td>91</td><td>32</td><td>40</td><td>35</td><td>30</td><td>36</td><td>29</td><td>44</td><td>38</td><td>40</td><td>38</td><td>56</td><td>40</td></tr><tr><td>\u2003Palate depth at incisive fossa</td><td>\u2013</td><td>3</td><td>11</td><td>10</td><td>10</td><td>9</td><td>10</td><td>5</td><td>10</td><td>13</td><td>11</td><td>10</td><td>9</td></tr><tr><td>\u2003Palate depth at M1</td><td>103</td><td>7</td><td>18</td><td>11</td><td>11</td><td>13</td><td>10</td><td>10</td><td>12</td><td>16</td><td>15</td><td>18</td><td>13</td></tr><tr><td colspan=\"14\">Mandible</td></tr><tr><td>\u2003Symphysis height</td><td>141</td><td>37</td><td>49</td><td>42</td><td>39</td><td>37</td><td>32</td><td>33</td><td>31</td><td>37</td><td>35</td><td>34</td><td>34</td></tr><tr><td>\u2003Symphysis width</td><td>142</td><td>26</td><td>28</td><td>25</td><td>20</td><td>21</td><td>18</td><td>18</td><td>20</td><td>24</td><td>18</td><td>17</td><td>14</td></tr><tr><td>\u2003Symphysis area at M1 (as an ellipse)<xref ref-type=\"table-fn\" rid=\"tblfn3\">\u2021</xref></td><td>146</td><td>757</td><td>1114</td><td>835</td><td>623</td><td>606</td><td>452</td><td>467</td><td>393</td><td>723</td><td>519</td><td>474</td><td>365</td></tr><tr><td>\u2003Corpus height at M1</td><td>150</td><td>38</td><td>42</td><td>36</td><td>34</td><td>32</td><td>30</td><td>26</td><td>29</td><td>36</td><td>31</td><td>31</td><td>28</td></tr><tr><td>\u2003Corpus breadth at M1</td><td>151</td><td>25</td><td>29</td><td>26</td><td>20</td><td>21</td><td>18</td><td>16</td><td>20</td><td>22</td><td>19</td><td>19</td><td>13</td></tr><tr><td>\u2003Corpus area at M1 (as an ellipse)<xref ref-type=\"table-fn\" rid=\"tblfn3\">\u2021</xref></td><td>152</td><td>742</td><td>955</td><td>736</td><td>540</td><td>539</td><td>405</td><td>326</td><td>425</td><td>631</td><td>458</td><td>469</td><td>296</td></tr><tr><td>\u2003Mental foramen height index<xref ref-type=\"table-fn\" rid=\"tblfn4\">\u00a7</xref></td><td>\u2013</td><td>51</td><td>50</td><td>54</td><td>58</td><td>53</td><td>50</td><td>40</td><td>46</td><td>49</td><td>48</td><td>48</td><td>50</td></tr></tbody></table>"
                         ], 
-                        "footer": [
+                        "footnotes": [
                             {
-                                "type": "paragraph", 
-                                "text": "At least in presumed males."
+                                "id": "tblfn1", 
+                                "label": "*", 
+                                "text": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "At least in presumed males."
+                                    }
+                                ]
                             }, 
                             {
-                                "type": "paragraph", 
-                                "text": "Post-orbital breadth/superior facial breadth \u00d7 100."
+                                "id": "tblfn2", 
+                                "label": "\u2020", 
+                                "text": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Post-orbital breadth/superior facial breadth \u00d7 100."
+                                    }
+                                ]
                             }, 
                             {
-                                "type": "paragraph", 
-                                "text": "Following the formula (\u03c0 \u00d7 (corpus height/2) \u00d7 (corpus breadth/2))."
+                                "id": "tblfn3", 
+                                "label": "\u2021", 
+                                "text": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Following the formula (\u03c0 \u00d7 (corpus height/2) \u00d7 (corpus breadth/2))."
+                                    }
+                                ]
                             }, 
                             {
-                                "type": "paragraph", 
-                                "text": "Height of mental foramen from alveolar border relative to corpus height at the mental foramen."
+                                "id": "tblfn4", 
+                                "label": "\u00a7", 
+                                "text": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Height of mental foramen from alveolar border relative to corpus height at the mental foramen."
+                                    }
+                                ]
                             }, 
                             {
-                                "type": "paragraph", 
-                                "text": "MP, Middle Pleistocene."
+                                "text": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "MP, Middle Pleistocene."
+                                    }
+                                ]
                             }, 
                             {
-                                "type": "paragraph", 
-                                "text": "Unless otherwise indicated measurements are defined as in <xref ref-type=\"bibr\" rid=\"bib70\">Wood (1991)</xref>. Chord distances are in mm. Data for <italic>H. naledi</italic> collected from original fossils or laser scans by DJdeR and HMG; comparative data collected by DJdeR on original fossils and casts and supplemented by data from <xref ref-type=\"bibr\" rid=\"bib70\">Wood (1991)</xref>."
+                                "text": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Unless otherwise indicated measurements are defined as in <xref ref-type=\"bibr\" rid=\"bib70\">Wood (1991)</xref>. Chord distances are in mm. Data for <italic>H. naledi</italic> collected from original fossils or laser scans by DJdeR and HMG; comparative data collected by DJdeR on original fossils and casts and supplemented by data from <xref ref-type=\"bibr\" rid=\"bib70\">Wood (1991)</xref>."
+                                    }
+                                ]
                             }
                         ]
                     }, 
@@ -5034,10 +5066,14 @@
                             "<table><thead><tr><th colspan=\"18\">Maxillary</th></tr><tr><th/><th/><th colspan=\"2\">I<sup>1</sup></th><th colspan=\"2\">I<sup>2</sup></th><th colspan=\"2\">C</th><th colspan=\"2\">P<sup>3</sup></th><th colspan=\"2\">P<sup>4</sup></th><th colspan=\"2\">M<sup>1</sup></th><th colspan=\"2\">M<sup>2</sup></th><th colspan=\"2\">M<sup>3</sup></th></tr><tr><th/><th/><th>MD</th><th>LL</th><th>MD</th><th>LL</th><th>MD</th><th>LL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th></tr></thead><tbody><tr><td rowspan=\"3\"><italic>Au. anamensis</italic></td><td>n</td><td>3</td><td>5</td><td>\u2013</td><td>2</td><td>6</td><td>7</td><td>7</td><td>6</td><td>5</td><td>3</td><td>12</td><td>10</td><td>10</td><td>8</td><td>9</td><td>8</td></tr><tr><td>mean</td><td>10.8</td><td>8.7</td><td>\u2013</td><td>7.3</td><td>11.0</td><td>10.6</td><td>9.9</td><td>12.6</td><td>8.9</td><td>13.6</td><td>11.5</td><td>12.9</td><td>13.0</td><td>14.4</td><td>12.5</td><td>14.2</td></tr><tr><td>range</td><td>9.1\u201312.4</td><td>8.2\u20139.3</td><td>\u2013</td><td>7.0\u20137.5</td><td>9.9\u201312.3</td><td>9.1\u201311.8</td><td>8.2\u201311.8</td><td>10.1\u201314.3</td><td>7.2\u201312.1</td><td>12.6\u201314.2</td><td>7.8\u201314.3</td><td>9.0\u201316.7</td><td>10.9\u201316.3</td><td>12.9\u201316.1</td><td>11.1\u201315.7</td><td>13.0\u201315.7</td></tr><tr><td rowspan=\"3\"><italic>Au. afarensis</italic></td><td>n</td><td>7</td><td>8</td><td>9</td><td>9</td><td>15</td><td>15</td><td>12</td><td>10</td><td>18</td><td>12</td><td>16</td><td>13</td><td>10</td><td>11</td><td>11</td><td>11</td></tr><tr><td>mean</td><td>10.7</td><td>8.4</td><td>7.5</td><td>7.2</td><td>9.9</td><td>10.8</td><td>8.8</td><td>12.4</td><td>9.1</td><td>12.4</td><td>12.0</td><td>13.4</td><td>12.9</td><td>14.6</td><td>12.7</td><td>14.5</td></tr><tr><td>range</td><td>9.9\u201311.8</td><td>7.1\u20139.7</td><td>6.6\u20138.2</td><td>6.2\u20138.1</td><td>8.8\u201311.6</td><td>9.3\u201312.5</td><td>7.7\u20139.7</td><td>11.3\u201313.4</td><td>7.6\u201310.8</td><td>11.1\u201314.5</td><td>10.5\u201313.8</td><td>12.0\u201315.0</td><td>12.1\u201313.6</td><td>13.4\u201315.2</td><td>10.9\u201314.8</td><td>13.1\u201316.3</td></tr><tr><td rowspan=\"3\"><italic>Au. africanus</italic></td><td>n</td><td>15</td><td>15</td><td>11</td><td>10</td><td>16</td><td>13</td><td>26</td><td>25</td><td>20</td><td>20</td><td>21</td><td>20</td><td>23</td><td>24</td><td>27</td><td>28</td></tr><tr><td>mean</td><td>10.7</td><td>8.3</td><td>6.9</td><td>6.8</td><td>9.9</td><td>10.3</td><td>9.2</td><td>12.7</td><td>9.5</td><td>13.4</td><td>12.9</td><td>13.9</td><td>14.1</td><td>15.7</td><td>14.2</td><td>16.0</td></tr><tr><td>range</td><td>9.4\u201312.5</td><td>7.4\u20139.1</td><td>5.8\u20138.0</td><td>5.6\u20137.9</td><td>8.8\u201311.0</td><td>8.7\u201312.0</td><td>8.5\u201310.2</td><td>10.7\u201314.5</td><td>7.2\u201311.0</td><td>12.4\u201315.3</td><td>11.7\u201314.4</td><td>12.9\u201315.3</td><td>12.1\u201316.3</td><td>12.8\u201317.9</td><td>11.2\u201316.9</td><td>13.1\u201318.6</td></tr><tr><td rowspan=\"3\"><italic>Au. sediba</italic></td><td>n</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>2</td><td>2</td></tr><tr><td>mean</td><td>10.1</td><td>6.9</td><td>7.2</td><td>6.6</td><td>9.0</td><td>8.8</td><td>9.0</td><td>11.2</td><td>9.3</td><td>12.1</td><td>12.9</td><td>12.0</td><td>12.9</td><td>13.7</td><td>13.0</td><td>13.5</td></tr><tr><td>range</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>12.6\u201313.3</td><td>12.9\u201314.1</td></tr><tr><td rowspan=\"3\"><italic>H. naledi</italic></td><td>n</td><td>\u2013</td><td>5</td><td>4</td><td>8</td><td>10</td><td>9</td><td>10</td><td>10</td><td>7</td><td>7</td><td>12</td><td>13</td><td>11</td><td>9</td><td>7</td><td>7</td></tr><tr><td>mean</td><td>9.4</td><td>6.5</td><td>6.6</td><td>6.2</td><td>8.1</td><td>8.6</td><td>8.0</td><td>10.5</td><td>8.1</td><td>11.0</td><td>11.6</td><td>11.7</td><td>12.2</td><td>12.8</td><td>11.6</td><td>12.4</td></tr><tr><td>range</td><td>8.8\u20139.8</td><td>6.3\u20137.0</td><td>6.3\u20137.0</td><td>5.8\u20136.6</td><td>7.3\u20138.9</td><td>8.0\u20139.6</td><td>7.7\u20138.4</td><td>9.8\u201311.0</td><td>7.7\u20138.7</td><td>10.5\u201311.2</td><td>10.5\u201312.4</td><td>11.2\u201312.4</td><td>11.0\u201313.0</td><td>11.9\u201313.6</td><td>11.0\u201312.7</td><td>11.4\u201313.4</td></tr><tr><td rowspan=\"3\"><italic>H. habilis</italic></td><td>n</td><td>2</td><td>2</td><td>4</td><td>4</td><td>2</td><td>3</td><td>7</td><td>7</td><td>8</td><td>8</td><td>13</td><td>13</td><td>7</td><td>7</td><td>7</td><td>7</td></tr><tr><td>mean</td><td>10.6</td><td>8.0</td><td>7.4</td><td>6.6</td><td>9.0</td><td>9.8</td><td>9.0</td><td>11.9</td><td>9.2</td><td>12.1</td><td>12.7</td><td>13.0</td><td>12.7</td><td>14.3</td><td>12.3</td><td>14.7</td></tr><tr><td>range</td><td>10.1\u201311.1</td><td>7.3\u20138.7</td><td>6.7\u20138.1</td><td>6.0\u20137.9</td><td>8.5\u20139.4</td><td>8.5\u201311.6</td><td>8.1\u20139.6</td><td>11.0\u201312.7</td><td>8.5\u20139.9</td><td>11.0\u201313.1</td><td>11.6\u201313.9</td><td>12.1\u201314.1</td><td>11.8\u201313.5</td><td>13.5\u201316.2</td><td>11.3\u201313.9</td><td>13.2\u201316.6</td></tr><tr><td rowspan=\"3\"><italic>H. rudolfensis</italic></td><td>n</td><td>1</td><td>1</td><td>\u2013</td><td>\u2013</td><td>1</td><td>1</td><td>1</td><td>1</td><td>2</td><td>2</td><td>2</td><td>2</td><td>2</td><td>2</td><td>1</td><td>1</td></tr><tr><td>mean</td><td>12.3</td><td>7.7</td><td>\u2013</td><td>\u2013</td><td>11.5</td><td>12.5</td><td>10.5</td><td>13.6</td><td>10.2</td><td>12.5</td><td>14.0</td><td>14.0</td><td>14.3</td><td>15.8</td><td>13.3</td><td>13.5</td></tr><tr><td>range</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>9.7\u201310.7</td><td>11.1\u201313.8</td><td>13.9\u201314.2</td><td>13.3\u201314.8</td><td>14.1\u201314.6</td><td>14.1\u201317.6</td><td>\u2013</td><td>\u2013</td></tr><tr><td rowspan=\"3\"><italic>H. erectus</italic></td><td>n</td><td>11</td><td>12</td><td>6</td><td>6</td><td>12</td><td>12</td><td>27</td><td>27</td><td>30</td><td>29</td><td>34</td><td>32</td><td>22</td><td>22</td><td>16</td><td>16</td></tr><tr><td>mean</td><td>10.3</td><td>8.1</td><td>7.7</td><td>8.0</td><td>9.5</td><td>10.0</td><td>8.5</td><td>11.8</td><td>8.1</td><td>11.6</td><td>12.2</td><td>13.2</td><td>12.0</td><td>13.3</td><td>10.5</td><td>12.8</td></tr><tr><td>range</td><td>8.1\u201312.6</td><td>7.0\u201311.7</td><td>6.0\u20138.3</td><td>6.9\u20138.5</td><td>8.5\u201311.1</td><td>9.0\u201311.8</td><td>7.1\u201310.1</td><td>9.5\u201313.8</td><td>7.0\u20139.4</td><td>9.9\u201313.4</td><td>10.1\u201314.6</td><td>11.0\u201315.9</td><td>10.3\u201313.6</td><td>10.9\u201315.5</td><td>8.7\u201314.7</td><td>10.4\u201315.8</td></tr><tr><td rowspan=\"3\"><italic>H. neanderthalensis</italic></td><td>n</td><td>28</td><td>37</td><td>35</td><td>41</td><td>28</td><td>29</td><td>16</td><td>17</td><td>21</td><td>19</td><td>23</td><td>24</td><td>27</td><td>28</td><td>22</td><td>21</td></tr><tr><td>mean</td><td>9.7</td><td>8.5</td><td>8.0</td><td>8.4</td><td>8.8</td><td>10.1</td><td>8.0</td><td>10.6</td><td>7.8</td><td>10.6</td><td>11.6</td><td>12.3</td><td>10.9</td><td>12.5</td><td>9.9</td><td>12.3</td></tr><tr><td>range</td><td>8.2\u201311.8</td><td>7.3\u20139.9</td><td>5.8\u20139.3</td><td>5.8\u20139.9</td><td>7.2\u201310.0</td><td>7.6\u201311.4</td><td>6.6\u20139.3</td><td>8.4\u201311.8</td><td>5.9\u201311.5</td><td>8.3\u201311.7</td><td>9.5\u201313.5</td><td>11.0\u201314.2</td><td>8.9\u201315.9</td><td>10.8\u201314.6</td><td>8.2\u201311.4</td><td>9.8\u201314.6</td></tr><tr><td rowspan=\"3\"><italic>H. heidelbergensis</italic></td><td>n</td><td>21</td><td>23</td><td>19</td><td>21</td><td>27</td><td>29</td><td>25</td><td>25</td><td>22</td><td>23</td><td>25</td><td>24</td><td>24</td><td>23</td><td>26</td><td>27</td></tr><tr><td>mean</td><td>9.6</td><td>7.8</td><td>7.7</td><td>7.8</td><td>8.8</td><td>9.8</td><td>7.9</td><td>10.6</td><td>7.6</td><td>10.3</td><td>11.2</td><td>11.9</td><td>10.2</td><td>12.3</td><td>8.9</td><td>11.6</td></tr><tr><td>range</td><td>8.7\u201310.7</td><td>7.1\u20139.9</td><td>7.2\u20138.4</td><td>7.3\u20138.6</td><td>8.1\u201311.0</td><td>8.8\u201311.8</td><td>7.1\u20139.0</td><td>9.2\u201312.2</td><td>7.0\u20138.8</td><td>9.1\u201311.5</td><td>9.9\u201312.3</td><td>10.3\u201313.2</td><td>8.1\u201312.1</td><td>11.1\u201313.8</td><td>7.6\u201311.0</td><td>10.0\u201313.2</td></tr><tr><td rowspan=\"3\">MP/LP African Homo</td><td>n</td><td>6</td><td>6</td><td>7</td><td>8</td><td>4</td><td>4</td><td>6</td><td>6</td><td>10</td><td>10</td><td>14</td><td>14</td><td>20</td><td>20</td><td>9</td><td>9</td></tr><tr><td>mean</td><td>9.0</td><td>7.8</td><td>7.4</td><td>7.2</td><td>8.9</td><td>9.7</td><td>8.4</td><td>10.8</td><td>8.1</td><td>10.8</td><td>12.3</td><td>13.2</td><td>11.0</td><td>12.9</td><td>9.2</td><td>11.7</td></tr><tr><td>range</td><td>6.3\u201310.9</td><td>6.6\u20138.7</td><td>6.0\u20139.3</td><td>6.1\u20138.5</td><td>8.2\u20139.5</td><td>8.8\u201310.0</td><td>8.1\u20138.7</td><td>9.9\u201311.8</td><td>7.5\u20139.3</td><td>9.4\u201312.8</td><td>10.4\u201314.0</td><td>12.0\u201315.0</td><td>7.8\u201313.0</td><td>11.0\u201315.0</td><td>7.6\u201310.2</td><td>10.0\u201313.2</td></tr></tbody></table>", 
                             "<table><thead><tr><th colspan=\"18\">Mandibular</th></tr><tr><th/><th/><th colspan=\"2\">I<sub>1</sub></th><th colspan=\"2\">I<sub>2</sub></th><th colspan=\"2\">C</th><th colspan=\"2\">P<sub>3</sub></th><th colspan=\"2\">P<sub>4</sub></th><th colspan=\"2\">M<sub>1</sub></th><th colspan=\"2\">M<sub>2</sub></th><th colspan=\"2\">M<sub>3</sub></th></tr><tr><th/><th/><th>MD</th><th>LL</th><th>MD</th><th>LL</th><th>MD</th><th>LL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th></tr></thead><tbody><tr><td rowspan=\"3\"><italic>Au. anamensis</italic></td><td>n</td><td>2</td><td>1</td><td>4</td><td>3</td><td>7</td><td>7</td><td>8</td><td>8</td><td>8</td><td>8</td><td>9</td><td>10</td><td>7</td><td>7</td><td>8</td><td>8</td></tr><tr><td>mean</td><td>6.9</td><td>7.4</td><td>7.8</td><td>8.3</td><td>10.0</td><td>10.4</td><td>12.4</td><td>9.2</td><td>9.1</td><td>11.3</td><td>12.9</td><td>12.3</td><td>14.0</td><td>13.4</td><td>15.3</td><td>13.4</td></tr><tr><td>range</td><td>6.8\u20136.9</td><td>\u2013</td><td>6.6\u20138.7</td><td>7.9\u20138.6</td><td>6.6\u201313.9</td><td>9.2\u201311.4</td><td>11.3\u201313.4</td><td>8.6\u201310.0</td><td>7.4\u20139.8</td><td>9.6\u201313.2</td><td>11.6\u201313.8</td><td>10.2\u201314.8</td><td>13.0\u201315.9</td><td>12.3\u201314.9</td><td>13.7\u201317.0</td><td>12.1\u201315.2</td></tr><tr><td rowspan=\"3\"><italic>Au. afarensis</italic></td><td>n</td><td>7</td><td>8</td><td>7</td><td>6</td><td>13</td><td>16</td><td>27</td><td>26</td><td>24</td><td>21</td><td>32</td><td>26</td><td>31</td><td>27</td><td>26</td><td>23</td></tr><tr><td>mean</td><td>6.7</td><td>7.1</td><td>6.7</td><td>8.0</td><td>8.8</td><td>10.4</td><td>9.6</td><td>10.6</td><td>9.8</td><td>11.0</td><td>13.1</td><td>12.6</td><td>14.3</td><td>13.4</td><td>15.3</td><td>13.5</td></tr><tr><td>range</td><td>5.6\u20137.7</td><td>5.6\u20138.0</td><td>5.0\u20138.0</td><td>6.7\u20138.8</td><td>7.5\u201311.7</td><td>8.0\u201312.4</td><td>7.9\u201312.6</td><td>8.9\u201313.8</td><td>7.7\u201311.4</td><td>9.8\u201312.8</td><td>10.1\u201314.8</td><td>11.0\u201314.0</td><td>12.1\u201316.5</td><td>11.1\u201315.2</td><td>13.4\u201318.1</td><td>11.3\u201315.3</td></tr><tr><td rowspan=\"3\"><italic>Au. africanus</italic></td><td>n</td><td>11</td><td>12</td><td>12</td><td>13</td><td>23</td><td>25</td><td>20</td><td>21</td><td>25</td><td>23</td><td>29</td><td>32</td><td>38</td><td>38</td><td>34</td><td>35</td></tr><tr><td>mean</td><td>6.2</td><td>6.7</td><td>7.2</td><td>7.9</td><td>9.4</td><td>10.1</td><td>9.7</td><td>11.5</td><td>10.4</td><td>11.6</td><td>14.0</td><td>13.0</td><td>15.7</td><td>14.5</td><td>16.3</td><td>14.6</td></tr><tr><td>range</td><td>4.8\u20136.9</td><td>5.7\u20137.9</td><td>5.6\u20138.1</td><td>6.6\u20139.2</td><td>8.5\u201310.7</td><td>8.2\u201312.1</td><td>8.8\u201311.0</td><td>9.9\u201313.9</td><td>8.7\u201312.3</td><td>9.3\u201313.2</td><td>12.4\u201315.8</td><td>11.2\u201315.1</td><td>14.2\u201317.7</td><td>12.8\u201316.8</td><td>13.5\u201318.5</td><td>12.2\u201316.8</td></tr><tr><td rowspan=\"3\"><italic>Au. sediba</italic></td><td>n</td><td>\u2013</td><td>1</td><td>\u2013</td><td>1</td><td>2</td><td>2</td><td>1</td><td>1</td><td>1</td><td>1</td><td>2</td><td>2</td><td>2</td><td>2</td><td>2</td><td>2</td></tr><tr><td>mean</td><td>\u2013</td><td>5.9</td><td>\u2013</td><td>6.6</td><td>7.7</td><td>8.0</td><td>8.1</td><td>9.2</td><td>8.8</td><td>9.7</td><td>13.1</td><td>11.4</td><td>14.5</td><td>12.8</td><td>14.9</td><td>13.2</td></tr><tr><td>range</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>7.3\u20138.0</td><td>7.4\u20138.6</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>13.1\u201313.1</td><td>11.3\u201311.5</td><td>14.4\u201314.5</td><td>12.3\u201313.2</td><td>14.9\u201314.9</td><td>12.5\u201313.6</td></tr><tr><td rowspan=\"3\"><italic>H. naledi</italic></td><td>n</td><td>7</td><td>7</td><td>5</td><td>6</td><td>7</td><td>7</td><td>9</td><td>10</td><td>6</td><td>6</td><td>11</td><td>11</td><td>9</td><td>9</td><td>6</td><td>5</td></tr><tr><td>mean</td><td>6.1</td><td>5.4</td><td>6.9</td><td>5.9</td><td>7.1</td><td>7.1</td><td>9.0</td><td>8.8</td><td>8.7</td><td>9.1</td><td>12.2</td><td>10.7</td><td>13.3</td><td>11.2</td><td>13.4</td><td>12.1</td></tr><tr><td>range</td><td>5.7\u20137.0</td><td>5.3\u20135.9</td><td>6.6\u20137.4</td><td>5.9\u20136.0</td><td>6.4\u20137.5</td><td>6.9\u20137.4</td><td>8.2\u20139.4</td><td>8.2\u20139.7</td><td>8.3\u20139.0</td><td>8.5\u201310.2</td><td>11.3\u201312.7</td><td>10.3\u201311.4</td><td>12.3\u201314.0</td><td>10.7\u201312.2</td><td>12.9\u201313.7</td><td>11.7\u201312.8</td></tr><tr><td rowspan=\"3\"><italic>H. habilis</italic></td><td>n</td><td>2</td><td>2</td><td>2</td><td>2</td><td>3</td><td>2</td><td>4</td><td>4</td><td>3</td><td>3</td><td>5</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td></tr><tr><td>mean</td><td>6.4</td><td>6.8</td><td>7.4</td><td>7.6</td><td>8.7</td><td>9.0</td><td>9.6</td><td>9.6</td><td>9.9</td><td>10.5</td><td>13.7</td><td>11.9</td><td>15.0</td><td>13.5</td><td>15.4</td><td>13.3</td></tr><tr><td>range</td><td>6.4\u20136.5</td><td>6.7\u20137.0</td><td>7.2\u20137.7</td><td>7.6\u20137.6</td><td>7.6\u20139.6</td><td>7.9\u201310.0</td><td>9.0\u201310.6</td><td>8.6\u201311.1</td><td>9.0\u201310.5</td><td>9.9\u201311.0</td><td>13.0\u201314.8</td><td>10.9\u201312.8</td><td>14.2\u201315.7</td><td>12.0\u201315.1</td><td>14.8\u201315.9</td><td>12.4\u201314.4</td></tr><tr><td rowspan=\"3\"><italic>H. rudolfensis</italic></td><td>n</td><td>\u2013</td><td>1</td><td>\u2013</td><td>1</td><td>\u2013</td><td>1</td><td>3</td><td>3</td><td>6</td><td>6</td><td>5</td><td>5</td><td>6</td><td>5</td><td>3</td><td>3</td></tr><tr><td>mean</td><td>\u2013</td><td>5.4</td><td>\u2013</td><td>6.7</td><td>\u2013</td><td>8.3</td><td>9.9</td><td>11.1</td><td>10.1</td><td>11.4</td><td>14.0</td><td>12.7</td><td>16.0</td><td>13.7</td><td>16.4</td><td>14.1</td></tr><tr><td>range</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>9.0\u201310.7</td><td>9.5\u201312.3</td><td>8.8\u201311.8</td><td>9.8\u201312.2</td><td>12.8\u201315.2</td><td>11.4\u201313.2</td><td>14.0\u201318.3</td><td>12.7\u201314.9</td><td>15.6\u201317.0</td><td>13.1\u201314.6</td></tr><tr><td rowspan=\"3\"><italic>H. erectus</italic></td><td>n</td><td>11</td><td>12</td><td>14</td><td>16</td><td>14</td><td>16</td><td>30</td><td>30</td><td>25</td><td>26</td><td>43</td><td>43</td><td>41</td><td>40</td><td>26</td><td>27</td></tr><tr><td>mean</td><td>6.2</td><td>6.4</td><td>7</td><td>7.2</td><td>8.7</td><td>9</td><td>9</td><td>10.1</td><td>8.7</td><td>10.1</td><td>12.7</td><td>11.9</td><td>13.3</td><td>12.5</td><td>12.7</td><td>11.7</td></tr><tr><td>range</td><td>4.8\u20137.4</td><td>5.8\u20137.1</td><td>5.3\u20138.1</td><td>6.4\u20138.5</td><td>7.0\u201310.3</td><td>8.0\u201310.4</td><td>7.0\u201312.0</td><td>8.2\u201312.0</td><td>7.2\u201310.3</td><td>8.0\u201312.5</td><td>9.9\u201314.8</td><td>10.1\u201313.3</td><td>11.3\u201315.3</td><td>10.8\u201314.3</td><td>10.0\u201315.2</td><td>10.0\u201314.2</td></tr><tr><td rowspan=\"3\"><italic>H. neanderthalensis</italic></td><td>n</td><td>9</td><td>16</td><td>23</td><td>31</td><td>36</td><td>41</td><td>20</td><td>21</td><td>23</td><td>25</td><td>38</td><td>40</td><td>26</td><td>27</td><td>18</td><td>20</td></tr><tr><td>mean</td><td>5.6</td><td>7.2</td><td>6.8</td><td>7.8</td><td>7.8</td><td>8.8</td><td>7.9</td><td>9.1</td><td>7.8</td><td>9.4</td><td>11.8</td><td>11.1</td><td>12.1</td><td>11.3</td><td>12.0</td><td>11.0</td></tr><tr><td>range</td><td>4.2\u20136.4</td><td>5.2\u20138.8</td><td>5.9\u20137.5</td><td>6.8\u20139.0</td><td>6.7\u20138.8</td><td>6.8\u201310.3</td><td>6.6\u20139.1</td><td>8.0\u201310.3</td><td>6.5\u20139.4</td><td>8.5\u201310.5</td><td>10.1\u201313.6</td><td>10.2\u201312.9</td><td>9.3\u201314.0</td><td>8.8\u201312.4</td><td>11.2\u201313.9</td><td>9.9\u201312.2</td></tr><tr><td rowspan=\"3\"><italic>H. heidelbergensis</italic></td><td>n</td><td>21</td><td>22</td><td>19</td><td>20</td><td>23</td><td>24</td><td>22</td><td>22</td><td>26</td><td>26</td><td>29</td><td>29</td><td>29</td><td>29</td><td>32</td><td>32</td></tr><tr><td>mean</td><td>5.6</td><td>6.7</td><td>6.5</td><td>7.3</td><td>7.6</td><td>8.7</td><td>7.9</td><td>8.9</td><td>7.2</td><td>8.7</td><td>11.3</td><td>10.6</td><td>11.2</td><td>10.5</td><td>11.5</td><td>10.0</td></tr><tr><td>range</td><td>4.8\u20136.5</td><td>6.0\u20137.5</td><td>6.0\u20137.2</td><td>6.6\u20138.0</td><td>6.9\u20139.0</td><td>7.3\u201310.0</td><td>7.2\u20139.0</td><td>7.6\u201311.6</td><td>6.6\u20138.8</td><td>7.2\u201311.7</td><td>10.4\u201313.8</td><td>9.6\u201313.0</td><td>9.7\u201314.6</td><td>8.5\u201313.9</td><td>9.7\u201313.2</td><td>8.6\u201312.5</td></tr><tr><td rowspan=\"3\">MP/LP African Homo</td><td>n</td><td>5</td><td>5</td><td>8</td><td>8</td><td>8</td><td>8</td><td>8</td><td>8</td><td>12</td><td>9</td><td>16</td><td>16</td><td>20</td><td>20</td><td>13</td><td>13</td></tr><tr><td>mean</td><td>6.0</td><td>6.8</td><td>6.8</td><td>7.2</td><td>8.8</td><td>9.6</td><td>8.6</td><td>9.8</td><td>8.6</td><td>10.3</td><td>13.1</td><td>11.8</td><td>12.5</td><td>11.7</td><td>12.4</td><td>11.5</td></tr><tr><td>range</td><td>5.7\u20136.4</td><td>6.1\u20137.2</td><td>5.6\u20138.3</td><td>6.4\u20138.0</td><td>7.8\u201310.0</td><td>8.8\u201310.3</td><td>7.7\u20139.0</td><td>8.6\u201311.2</td><td>6.9\u20139.6</td><td>9.3\u201311.4</td><td>10.7\u201314.2</td><td>10.0\u201313.0</td><td>10.8\u201315.0</td><td>9.2\u201313.6</td><td>10.6\u201313.5</td><td>9.9\u201312.7</td></tr></tbody></table>"
                         ], 
-                        "footer": [
+                        "footnotes": [
                             {
-                                "type": "paragraph", 
-                                "text": "MP, Middle Pleistocene and LP, Late Pleistocene."
+                                "text": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "MP, Middle Pleistocene and LP, Late Pleistocene."
+                                    }
+                                ]
                             }
                         ]
                     }, 
@@ -5190,10 +5226,14 @@
                         "tables": [
                             "<table><thead><tr><th>Specimen ID</th><th>Side</th><th>AP subtrochanteric breadth</th><th>ML subtrochanteric breadth</th><th>Mass (a)</th><th>Mass (b)</th></tr></thead><tbody><tr><td>U.W. 101-002</td><td>R</td><td>18.5</td><td>23.6</td><td>40.0</td><td>44.7</td></tr><tr><td>U.W. 101-003</td><td>R</td><td>21.6</td><td>31.4</td><td>54.5</td><td>55.8</td></tr><tr><td>U.W. 101-018</td><td>R</td><td>18.1</td><td>23.8</td><td>39.7</td><td>44.4</td></tr><tr><td>U.W. 101-226</td><td>L</td><td>19.1</td><td>24.0</td><td>41.3</td><td>45.7</td></tr><tr><td>U.W. 101-1136</td><td>R</td><td>16.9</td><td>25.5</td><td>39.7</td><td>44.4</td></tr><tr><td>U.W. 101-1391</td><td>R</td><td>18.8</td><td>23.9</td><td>40.8</td><td>45.3</td></tr><tr><td>U.W. 101-1475</td><td>L</td><td>18.8</td><td>29.0</td><td>46.5</td><td>49.7</td></tr><tr><td>U.W. 101-1482</td><td>L</td><td>20.7</td><td>28.9</td><td>49.7</td><td>52.1</td></tr></tbody></table>"
                         ], 
-                        "footer": [
+                        "footnotes": [
                             {
-                                "type": "paragraph", 
-                                "text": "Regression equations described in \u2018Materials and methods\u2019. Mass (a) based on forensic statures from European individuals. Mass (b) based on multiple population sample. The two estimates diverge somewhat for smaller femora."
+                                "text": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Regression equations described in \u2018Materials and methods\u2019. Mass (a) based on forensic statures from European individuals. Mass (b) based on multiple population sample. The two estimates diverge somewhat for smaller femora."
+                                    }
+                                ]
                             }
                         ]
                     }, 
@@ -5835,3291 +5875,1238 @@
         ], 
         "references": [
             {
-                "article_title": "A juvenile early hominin skeleton from Dikika, Ethiopia", 
-                "lpage": "301", 
-                "doi": "10.1038/nature05047", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Alemseged", 
-                        "given-names": "Z", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Spoor", 
-                        "given-names": "F", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kimbel", 
-                        "given-names": "WH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Bobe", 
-                        "given-names": "R", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Geraads", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Reed", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Wynn", 
-                        "given-names": "JG", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "A juvenile early hominin skeleton from Dikika, Ethiopia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib1", 
+                "date": "2006", 
+                "articleTitle": "A juvenile early hominin skeleton from Dikika, Ethiopia", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "443", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature05047", 
-                "fpage": "296", 
-                "year": "2006", 
-                "position": 1, 
-                "ref": "AlemsegedZSpoorFKimbelWHBobeRGeraadsDReedDWynnJG2006A juvenile early hominin skeleton from Dikika, EthiopiaNature44329630110.1038/nature05047", 
-                "id": "bib1"
+                "pages": {
+                    "first": "296", 
+                    "last": "301", 
+                    "range": "296\u2013301"
+                }, 
+                "doi": "10.1038/nature05047"
             }, 
             {
-                "article_title": "On manual proportions and pad-to-pad precision grasping in Austalopithecus afarensis", 
-                "lpage": "92", 
-                "doi": "10.1016/j.jhevol.2014.02.006", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Alm\u00e9cija", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Alba", 
-                        "given-names": "DM", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "On manual proportions and pad-to-pad precision grasping in <italic>Austalopithecus afarensis</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib2", 
+                "date": "2014", 
+                "articleTitle": "On manual proportions and pad-to-pad precision grasping in <italic>Austalopithecus afarensis</italic>", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "73", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1016/j.jhevol.2014.02.006", 
-                "fpage": "88", 
-                "year": "2014", 
-                "position": 2, 
-                "ref": "Alm\u00e9cijaSAlbaDM2014On manual proportions and pad-to-pad precision grasping in Austalopithecus afarensisJournal of Human Evolution73889210.1016/j.jhevol.2014.02.006", 
-                "id": "bib2"
+                "pages": {
+                    "first": "88", 
+                    "last": "92", 
+                    "range": "88\u201392"
+                }, 
+                "doi": "10.1016/j.jhevol.2014.02.006"
             }, 
             {
-                "article_title": "Natural history of Homo erectus", 
-                "doi": "10.1002/ajpa.10399", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Ant\u00f3n", 
-                        "given-names": "SC", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Natural history of <italic>Homo erectus</italic>", 
-                "publication-type": "journal", 
-                "lpage": "170", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/ajpa.10399", 
-                "fpage": "126", 
-                "year": "2003", 
-                "position": 3, 
-                "ref": "Ant\u00f3nSC2003Natural history of Homo erectusAmerican Journal of Physical AnthropologySuppl 3712617010.1002/ajpa.10399", 
-                "id": "bib3"
+                "type": "journal", 
+                "id": "bib3", 
+                "date": "2003", 
+                "articleTitle": "Natural history of <italic>Homo erectus</italic>", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
+                "pages": {
+                    "first": "126", 
+                    "last": "170", 
+                    "range": "126\u2013170"
+                }, 
+                "doi": "10.1002/ajpa.10399"
             }, 
             {
-                "article_title": "Human evolution. Evolution of early Homo: an integrated biological perspective", 
-                "doi": "10.1126/science.1236828", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Ant\u00f3n", 
-                        "given-names": "SC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Potts", 
-                        "given-names": "R", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Aiello", 
-                        "given-names": "LC", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Human evolution. Evolution of early <italic>Homo</italic>: an integrated biological perspective", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib4", 
+                "date": "2014", 
+                "articleTitle": "Human evolution. Evolution of early <italic>Homo</italic>: an integrated biological perspective", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "345", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1236828", 
-                "fpage": "1236828", 
-                "year": "2014", 
-                "position": 4, 
-                "ref": "Ant\u00f3nSCPottsRAielloLC2014Human evolution. Evolution of early Homo: an integrated biological perspectiveScience345123682810.1126/science.1236828", 
-                "id": "bib4"
+                "pages": "1236828", 
+                "doi": "10.1126/science.1236828"
             }, 
             {
-                "article_title": "Australopithecus garhi: a new species of early hominid from Ethiopia", 
-                "lpage": "635", 
-                "doi": "10.1126/science.284.5414.629", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Asfaw", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "White", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Lovejoy", 
-                        "given-names": "O", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Latimer", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Simpson", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Suwa", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "<italic>Australopithecus garhi</italic>: a new species of early hominid from Ethiopia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib5", 
+                "date": "1999", 
+                "articleTitle": "<italic>Australopithecus garhi</italic>: a new species of early hominid from Ethiopia", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "284", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.284.5414.629", 
-                "fpage": "629", 
-                "year": "1999", 
-                "position": 5, 
-                "ref": "AsfawBWhiteTLovejoyOLatimerBSimpsonSSuwaG1999Australopithecus garhi: a new species of early hominid from EthiopiaScience28462963510.1126/science.284.5414.629", 
-                "id": "bib5"
+                "pages": {
+                    "first": "629", 
+                    "last": "635", 
+                    "range": "629\u2013635"
+                }, 
+                "doi": "10.1126/science.284.5414.629"
             }, 
             {
-                "article_title": "Australopithecus sediba: a new species of Homo-like australopith from South Africa", 
-                "lpage": "204", 
-                "doi": "10.1126/science.1184944", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "de Ruiter", 
-                        "given-names": "DJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Schmid", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Carlson", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Dirks", 
-                        "given-names": "PH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kibii", 
-                        "given-names": "JM", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "<italic>Australopithecus sediba</italic>: a new species of <italic>Homo</italic>-like australopith from South Africa", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib6", 
+                "date": "2010", 
+                "articleTitle": "<italic>Australopithecus sediba</italic>: a new species of <italic>Homo</italic>-like australopith from South Africa", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "328", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1184944", 
-                "fpage": "195", 
-                "year": "2010", 
-                "position": 6, 
-                "ref": "BergerLRde RuiterDJChurchillSESchmidPCarlsonKJDirksPHKibiiJM2010Australopithecus sediba: a new species of Homo-like australopith from South AfricaScience32819520410.1126/science.1184944", 
-                "id": "bib6"
+                "pages": {
+                    "first": "195", 
+                    "last": "204", 
+                    "range": "195\u2013204"
+                }, 
+                "doi": "10.1126/science.1184944"
             }, 
             {
-                "article_title": "On the variability of the Dmanisi mandibles", 
-                "doi": "10.1371/journal.pone.0088212", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Berm\u00fadez de Castro", 
-                        "given-names": "JM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Martin\u00f3n-Torres", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sier", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Mart\u00edn-Franc\u00e9s", 
-                        "given-names": "L", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "On the variability of the Dmanisi mandibles", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib7", 
+                "date": "2014", 
+                "articleTitle": "On the variability of the Dmanisi mandibles", 
+                "journal": {
+                    "name": [
+                        "PLOS ONE"
+                    ]
+                }, 
                 "volume": "9", 
-                "source": "PLOS ONE", 
-                "reference_id": "10.1371/journal.pone.0088212", 
-                "fpage": "e88212", 
-                "year": "2014", 
-                "position": 7, 
-                "ref": "Berm\u00fadez de CastroJMMartin\u00f3n-TorresMSierMJMart\u00edn-Franc\u00e9sL2014On the variability of the Dmanisi mandiblesPLOS ONE9e8821210.1371/journal.pone.0088212", 
-                "id": "bib7"
+                "pages": "e88212", 
+                "doi": "10.1371/journal.pone.0088212"
             }, 
             {
-                "article_title": "Late Pliocene Homo and hominid land use from western Olduvai Gorge, Tanzania", 
-                "lpage": "1221", 
-                "doi": "10.1126/science.1075374", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Blumenschine", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Peters", 
-                        "given-names": "CR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Masao", 
-                        "given-names": "FT", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Clarke", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Deino", 
-                        "given-names": "AL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hay", 
-                        "given-names": "RL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Swisher", 
-                        "given-names": "CC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Stanistreet", 
-                        "given-names": "IG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ashley", 
-                        "given-names": "GM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "McHenry", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sikes", 
-                        "given-names": "NE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Van Der Merwe", 
-                        "given-names": "NJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tactikos", 
-                        "given-names": "JC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Cushing", 
-                        "given-names": "AE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Deocampo", 
-                        "given-names": "DM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Njau", 
-                        "given-names": "JK", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ebert", 
-                        "given-names": "JI", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Late Pliocene <italic>Homo</italic> and hominid land use from western Olduvai Gorge, Tanzania", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib8", 
+                "date": "2003", 
+                "articleTitle": "Late Pliocene <italic>Homo</italic> and hominid land use from western Olduvai Gorge, Tanzania", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "299", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1075374", 
-                "fpage": "1217", 
-                "year": "2003", 
-                "position": 8, 
-                "ref": "BlumenschineRJPetersCRMasaoFTClarkeRJDeinoALHayRLSwisherCCStanistreetIGAshleyGMMcHenryLJSikesNEVan Der MerweNJTactikosJCCushingAEDeocampoDMNjauJKEbertJI2003Late Pliocene Homo and hominid land use from western Olduvai Gorge, TanzaniaScience2991217122110.1126/science.1075374", 
-                "id": "bib8"
+                "pages": {
+                    "first": "1217", 
+                    "last": "1221", 
+                    "range": "1217\u20131221"
+                }, 
+                "doi": "10.1126/science.1075374"
             }, 
             {
-                "article_title": "A gracile hominid cranium from upper member G of the Shungura formation, Ethiopia", 
-                "lpage": "108", 
-                "doi": "10.1002/ajpa.1330460113", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Boaz", 
-                        "given-names": "NT", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Howell", 
-                        "given-names": "FC", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "A gracile hominid cranium from upper member G of the Shungura formation, Ethiopia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib9", 
+                "date": "1977", 
+                "articleTitle": "A gracile hominid cranium from upper member G of the Shungura formation, Ethiopia", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
                 "volume": "46", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/ajpa.1330460113", 
-                "fpage": "93", 
-                "year": "1977", 
-                "position": 9, 
-                "ref": "BoazNTHowellFC1977A gracile hominid cranium from upper member G of the Shungura formation, EthiopiaAmerican Journal of Physical Anthropology469310810.1002/ajpa.1330460113", 
-                "id": "bib9"
+                "pages": {
+                    "first": "93", 
+                    "last": "108", 
+                    "range": "93\u2013108"
+                }, 
+                "doi": "10.1002/ajpa.1330460113"
             }, 
             {
-                "article_title": "A new small-bodied hominin from the Late Pleistocene of Flores, Indonesia", 
-                "lpage": "1061", 
-                "doi": "10.1038/nature02999", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Brown", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sutikna", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Morwood", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Soejono", 
-                        "given-names": "RP", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Saptomo", 
-                        "given-names": "EW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Due", 
-                        "given-names": "RA", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "A new small-bodied hominin from the Late Pleistocene of Flores, Indonesia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib10", 
+                "date": "2004", 
+                "articleTitle": "A new small-bodied hominin from the Late Pleistocene of Flores, Indonesia", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "431", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature02999", 
-                "fpage": "1055", 
-                "year": "2004", 
-                "position": 10, 
-                "ref": "BrownPSutiknaTMorwoodMJSoejonoRPSaptomoEWDueRA2004A new small-bodied hominin from the Late Pleistocene of Flores, IndonesiaNature4311055106110.1038/nature02999", 
-                "id": "bib10"
+                "pages": {
+                    "first": "1055", 
+                    "last": "1061", 
+                    "range": "1055\u20131061"
+                }, 
+                "doi": "10.1038/nature02999"
             }, 
             {
-                "article_title": "The endocast of MH1, Australopithecus sediba", 
-                "lpage": "1407", 
-                "doi": "10.1126/science.1203922", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Carlson", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Stout", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jashashvili", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "de Ruiter", 
-                        "given-names": "DJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tafforeau", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Carlson", 
-                        "given-names": "K", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The endocast of MH1, <italic>Australopithecus sediba</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib11", 
+                "date": "2011", 
+                "articleTitle": "The endocast of MH1, <italic>Australopithecus sediba</italic>", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "333", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1203922", 
-                "fpage": "1402", 
-                "year": "2011", 
-                "position": 11, 
-                "ref": "CarlsonKJStoutDJashashviliTde RuiterDJTafforeauPCarlsonKBergerLR2011The endocast of MH1, Australopithecus sedibaScience3331402140710.1126/science.1203922", 
-                "id": "bib11"
+                "pages": {
+                    "first": "1402", 
+                    "last": "1407", 
+                    "range": "1402\u20131407"
+                }, 
+                "doi": "10.1126/science.1203922"
             }, 
             {
-                "article_title": "The upper limb of Australopithecus sediba", 
-                "doi": "10.1126/science.1233477", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Holliday", 
-                        "given-names": "TW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Carlson", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jashashvili", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Macias", 
-                        "given-names": "ME", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Mathews", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sparling", 
-                        "given-names": "TL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Schmid", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "de Ruiter", 
-                        "given-names": "DJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The upper limb of <italic>Australopithecus sediba</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib12", 
+                "date": "2013", 
+                "articleTitle": "The upper limb of <italic>Australopithecus sediba</italic>", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "340", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1233477", 
-                "fpage": "1233477", 
-                "year": "2013", 
-                "position": 12, 
-                "ref": "ChurchillSEHollidayTWCarlsonKJJashashviliTMaciasMEMathewsSSparlingTLSchmidPde RuiterDJBergerLR2013The upper limb of Australopithecus sedibaScience340123347710.1126/science.1233477", 
-                "id": "bib12"
+                "pages": "1233477", 
+                "doi": "10.1126/science.1233477"
             }, 
             {
-                "publisher_loc": "Johannesburg", 
-                "article_doi": "10.7554/eLife.09560", 
-                "publisher_name": "University of the Witwatersrand", 
-                "year": "1977", 
-                "publication-type": "book", 
-                "source": "Unpublished PhD dissertation", 
-                "authors": [
-                    {
-                        "surname": "Clarke", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
+                "type": "book", 
+                "id": "bib13", 
+                "date": "1977", 
+                "bookTitle": "Unpublished PhD dissertation", 
+                "publisher": {
+                    "name": [
+                        "University of the Witwatersrand"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Johannesburg"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Johannesburg"
+                            ]
+                        }
                     }
-                ], 
-                "position": 13, 
-                "ref": "ClarkeRJ1977Unpublished PhD dissertationJohannesburgUniversity of the Witwatersrand", 
-                "id": "bib13"
+                }
             }, 
             {
-                "article_title": "Latest information on Sterkfontein's Australopithecus skeleton and a new look at Australopithecus", 
-                "lpage": "449", 
-                "doi": "10.1590/S0038-23532008000600015", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Clarke", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Latest information on Sterkfontein's <italic>Australopithecus</italic> skeleton and a new look at <italic>Australopithecus</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib14", 
+                "date": "2008", 
+                "articleTitle": "Latest information on Sterkfontein's <italic>Australopithecus</italic> skeleton and a new look at <italic>Australopithecus</italic>", 
+                "journal": {
+                    "name": [
+                        "South African Journal of Science"
+                    ]
+                }, 
                 "volume": "104", 
-                "source": "South African Journal of Science", 
-                "reference_id": "10.1590/S0038-23532008000600015", 
-                "fpage": "443", 
-                "year": "2008", 
-                "position": 14, 
-                "ref": "ClarkeRJ2008Latest information on Sterkfontein's Australopithecus skeleton and a new look at AustralopithecusSouth African Journal of Science10444344910.1590/S0038-23532008000600015", 
-                "id": "bib14"
+                "pages": {
+                    "first": "443", 
+                    "last": "449", 
+                    "range": "443\u2013449"
+                }, 
+                "doi": "10.1590/S0038-23532008000600015"
             }, 
             {
-                "article_title": "Bayesian analysis of a morphological supermatrix sheds light on controversial fossil hominin relationships", 
-                "doi": "10.1098/rspb.2015.0943", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Dembo", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Matzke", 
-                        "given-names": "NJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Mooers", 
-                        "given-names": "A\u00d8", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Collard", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Bayesian analysis of a morphological supermatrix sheds light on controversial fossil hominin relationships", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib15", 
+                "date": "2015", 
+                "articleTitle": "Bayesian analysis of a morphological supermatrix sheds light on controversial fossil hominin relationships", 
+                "journal": {
+                    "name": [
+                        "Proceedings of the Royal Society B"
+                    ]
+                }, 
                 "volume": "282", 
-                "source": "Proceedings of the Royal Society B", 
-                "reference_id": "10.1098/rspb.2015.0943", 
-                "fpage": "20150943", 
-                "year": "2015", 
-                "position": 15, 
-                "ref": "DemboMMatzkeNJMooersA\u00d8CollardM2015Bayesian analysis of a morphological supermatrix sheds light on controversial fossil hominin relationshipsProceedings of the Royal Society B2822015094310.1098/rspb.2015.0943", 
-                "id": "bib15"
+                "pages": "20150943", 
+                "doi": "10.1098/rspb.2015.0943"
             }, 
             {
-                "article_title": "The lower limb and mechanics of walking in Australopithecus sediba", 
-                "doi": "10.1126/science.1232999", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "DeSilva", 
-                        "given-names": "JM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Holt", 
-                        "given-names": "KG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Carlson", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Walker", 
-                        "given-names": "CS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Zipfel", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The lower limb and mechanics of walking in <italic>Australopithecus sediba</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib16", 
+                "date": "2013", 
+                "articleTitle": "The lower limb and mechanics of walking in <italic>Australopithecus sediba</italic>", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "340", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1232999", 
-                "fpage": "1232999", 
-                "year": "2013", 
-                "position": 16, 
-                "ref": "DeSilvaJMHoltKGChurchillSECarlsonKJWalkerCSZipfelBBergerLR2013The lower limb and mechanics of walking in Australopithecus sedibaScience340123299910.1126/science.1232999", 
-                "id": "bib16"
+                "pages": "1232999", 
+                "doi": "10.1126/science.1232999"
             }, 
             {
-                "article_title": "Geological and taphonomic evidence for deliberate body disposal by the primitive hominin species Homo naledi from the Dinaledi Chamber, South Africa", 
-                "doi": "10.7554/eLife.09561", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Dirks", 
-                        "given-names": "PHGM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Roberts", 
-                        "given-names": "EM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kramers", 
-                        "given-names": "JD", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hawks", 
-                        "given-names": "J", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Randolph-Quinney", 
-                        "given-names": "PS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Elliott", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Musiba", 
-                        "given-names": "CM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "de Ruiter", 
-                        "given-names": "DJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Schmid", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Backwell", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Belyanin", 
-                        "given-names": "GA", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Boshoff", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hunter", 
-                        "given-names": "KL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Feuerriegel", 
-                        "given-names": "EM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Gurtov", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "du G Harrison ", 
-                        "given-names": "J", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hunter", 
-                        "given-names": "R", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kruger", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Morris", 
-                        "given-names": "H", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Makhubela", 
-                        "given-names": "TV", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Peixotto", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tucker", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Geological and taphonomic evidence for deliberate body disposal by the primitive hominin species <italic>Homo naledi</italic> from the Dinaledi Chamber, South Africa", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib17", 
+                "date": "2015", 
+                "articleTitle": "Geological and taphonomic evidence for deliberate body disposal by the primitive hominin species <italic>Homo naledi</italic> from the Dinaledi Chamber, South Africa", 
+                "journal": {
+                    "name": [
+                        "eLife"
+                    ]
+                }, 
                 "volume": "4", 
-                "source": "eLife", 
-                "reference_id": "10.7554/eLife.09561", 
-                "fpage": "e09651", 
-                "year": "2015", 
-                "position": 17, 
-                "ref": "DirksPHGMBergerLRRobertsEMKramersJDHawksJRandolph-QuinneyPSElliottMMusibaCMChurchillSEde RuiterDJSchmidPBackwellLRBelyaninGABoshoffPHunterKLFeuerriegelEMGurtovAdu G Harrison JHunterRKrugerAMorrisHMakhubelaTVPeixottoBTuckerS2015Geological and taphonomic evidence for deliberate body disposal by the primitive hominin species Homo naledi from the Dinaledi Chamber, South AfricaeLife4e0965110.7554/eLife.09561", 
-                "id": "bib17"
+                "pages": "e09651", 
+                "doi": "10.7554/eLife.09561"
             }, 
             {
-                "article_title": "First partial skeleton of a 1.34-million-year-old Paranthropus boisei from Bed II, Olduvai Gorge, Tanzania", 
-                "doi": "10.1371/journal.pone.0080347", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Dom\u00ednguez-Rodrigo", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Pickering", 
-                        "given-names": "TR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Baquedano", 
-                        "given-names": "E", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Mabulla", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Mark", 
-                        "given-names": "DF", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Musiba", 
-                        "given-names": "C", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Bunn", 
-                        "given-names": "HT", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Uribelarrea", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Smith", 
-                        "given-names": "V", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Diez-Martin", 
-                        "given-names": "F", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "P\u00e9rez-Gonz\u00e1lez", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "S\u00e1nchez", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Santonja", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Barboni", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Gidna", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ashley", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Yravedra", 
-                        "given-names": "J", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Heaton", 
-                        "given-names": "JL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Arriaza", 
-                        "given-names": "MC", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "First partial skeleton of a 1.34-million-year-old <italic>Paranthropus boisei</italic> from Bed II, Olduvai Gorge, Tanzania", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib18", 
+                "date": "2013", 
+                "articleTitle": "First partial skeleton of a 1.34-million-year-old <italic>Paranthropus boisei</italic> from Bed II, Olduvai Gorge, Tanzania", 
+                "journal": {
+                    "name": [
+                        "PLOS ONE"
+                    ]
+                }, 
                 "volume": "8", 
-                "source": "PLOS ONE", 
-                "reference_id": "10.1371/journal.pone.0080347", 
-                "fpage": "e80347", 
-                "year": "2013", 
-                "position": 18, 
-                "ref": "Dom\u00ednguez-RodrigoMPickeringTRBaquedanoEMabullaAMarkDFMusibaCBunnHTUribelarreaDSmithVDiez-MartinFP\u00e9rez-Gonz\u00e1lezAS\u00e1nchezPSantonjaMBarboniDGidnaAAshleyGYravedraJHeatonJLArriazaMC2013First partial skeleton of a 1.34-million-year-old Paranthropus boisei from Bed II, Olduvai Gorge, TanzaniaPLOS ONE8e8034710.1371/journal.pone.0080347", 
-                "id": "bib18"
+                "pages": "e80347", 
+                "doi": "10.1371/journal.pone.0080347"
             }, 
             {
-                "article_title": "Associated cranial and forelimb remains attributed to Australopithecus afarensis from Hadar, Ethiopia", 
-                "lpage": "642", 
-                "doi": "10.1016/j.jhevol.2005.02.005", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Drapeau", 
-                        "given-names": "MS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ward", 
-                        "given-names": "CV", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kimbel", 
-                        "given-names": "WH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Johanson", 
-                        "given-names": "DC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Rak", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Associated cranial and forelimb remains attributed to <italic>Australopithecus afarensis</italic> from Hadar, Ethiopia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib19", 
+                "date": "2005", 
+                "articleTitle": "Associated cranial and forelimb remains attributed to <italic>Australopithecus afarensis</italic> from Hadar, Ethiopia", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "48", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1016/j.jhevol.2005.02.005", 
-                "fpage": "593", 
-                "year": "2005", 
-                "position": 19, 
-                "ref": "DrapeauMSWardCVKimbelWHJohansonDCRakY2005Associated cranial and forelimb remains attributed to Australopithecus afarensis from Hadar, EthiopiaJournal of Human Evolution4859364210.1016/j.jhevol.2005.02.005", 
-                "id": "bib19"
+                "pages": {
+                    "first": "593", 
+                    "last": "642", 
+                    "range": "593\u2013642"
+                }, 
+                "doi": "10.1016/j.jhevol.2005.02.005"
             }, 
             {
-                "article_title": "The brain of LB1, Homo floresiensis", 
-                "lpage": "245", 
-                "doi": "10.1126/science.1109727", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Falk", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hildebolt", 
-                        "given-names": "C", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Smith", 
-                        "given-names": "K", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Morwood", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sutikna", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Brown", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jatmiko", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Saptomo", 
-                        "given-names": "EW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Brunsden", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Prior", 
-                        "given-names": "F", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The brain of LB1, <italic>Homo floresiensis</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib20", 
+                "date": "2005", 
+                "articleTitle": "The brain of LB1, <italic>Homo floresiensis</italic>", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "308", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1109727", 
-                "fpage": "242", 
-                "year": "2005", 
-                "position": 20, 
-                "ref": "FalkDHildeboltCSmithKMorwoodMJSutiknaTBrownPJatmikoSaptomoEWBrunsdenBPriorF2005The brain of LB1, Homo floresiensisScience30824224510.1126/science.1109727", 
-                "id": "bib20"
+                "pages": {
+                    "first": "242", 
+                    "last": "245", 
+                    "range": "242\u2013245"
+                }, 
+                "doi": "10.1126/science.1109727"
             }, 
             {
-                "article_title": "Une nouvelle m\u00e9thode de d\u00e9termination de la taille", 
-                "lpage": "273", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Fully", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Une nouvelle m\u00e9thode de d\u00e9termination de la taille", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib21", 
+                "date": "1956", 
+                "articleTitle": "Une nouvelle m\u00e9thode de d\u00e9termination de la taille", 
+                "journal": {
+                    "name": [
+                        "Annales de M\u00e9decine L\u00e9gale, Criminologie, Police Scientifique et Toxicologie"
+                    ]
+                }, 
                 "volume": "36", 
-                "source": "Annales de M\u00e9decine L\u00e9gale, Criminologie, Police Scientifique et Toxicologie", 
-                "fpage": "266", 
-                "year": "1956", 
-                "position": 21, 
-                "ref": "FullyG1956Une nouvelle m\u00e9thode de d\u00e9termination de la tailleAnnales de M\u00e9decine L\u00e9gale, Criminologie, Police Scientifique et Toxicologie36266273", 
-                "id": "bib21"
+                "pages": {
+                    "first": "266", 
+                    "last": "273", 
+                    "range": "266\u2013273"
+                }
             }, 
             {
-                "article_title": "Earliest Pleistocene hominid cranial remains from Dmanisi, Republic of Georgia: taxonomy, geological setting and age", 
-                "lpage": "1025", 
-                "doi": "10.1126/science.288.5468.1019", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Gabunia", 
-                        "given-names": "L", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Vekua", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Lordkipanidze", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Swisher", 
-                        "given-names": "CC", 
-                        "group-type": "author", 
-                        "suffix": "III"
-                    }, 
-                    {
-                        "surname": "Ferring", 
-                        "given-names": "R", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Justus", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Nioradze", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tvalchrelidze", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ant\u00f3n", 
-                        "given-names": "SC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Bosinski", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "J\u00f6ris", 
-                        "given-names": "O", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Lumley", 
-                        "given-names": "MA", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Majsuradze", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Mouskhelishvili", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Earliest Pleistocene hominid cranial remains from Dmanisi, Republic of Georgia: taxonomy, geological setting and age", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib22", 
+                "date": "2000", 
+                "articleTitle": "Earliest Pleistocene hominid cranial remains from Dmanisi, Republic of Georgia: taxonomy, geological setting and age", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "288", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.288.5468.1019", 
-                "fpage": "1019", 
-                "year": "2000", 
-                "position": 22, 
-                "ref": "GabuniaLVekuaALordkipanidzeDSwisherCCIIIFerringRJustusANioradzeMTvalchrelidzeMAnt\u00f3nSCBosinskiGJ\u00f6risOLumleyMAMajsuradzeGMouskhelishviliA2000Earliest Pleistocene hominid cranial remains from Dmanisi, Republic of Georgia: taxonomy, geological setting and ageScience2881019102510.1126/science.288.5468.1019", 
-                "id": "bib22"
+                "pages": {
+                    "first": "1019", 
+                    "last": "1025", 
+                    "range": "1019\u20131025"
+                }, 
+                "doi": "10.1126/science.288.5468.1019"
             }, 
             {
-                "article_title": "Associated cranial and postcranial bones of Australopithecus boisei", 
-                "publisher_loc": "New York", 
-                "article_doi": "10.7554/eLife.09560", 
-                "publisher_name": "Aldine de Gruyter", 
-                "authors": [
-                    {
-                        "surname": "Grausz", 
-                        "given-names": "HM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Leakey", 
-                        "given-names": "R", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Walker", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ward", 
-                        "given-names": "C", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Grine", 
-                        "given-names": "FE", 
-                        "group-type": "editor"
+                "type": "book-chapter", 
+                "id": "bib23", 
+                "date": "1988", 
+                "bookTitle": "Evolutionary history of the \u2018Robust\u2019 Australopithecines", 
+                "chapterTitle": "Associated cranial and postcranial bones of <italic>Australopithecus boisei</italic>", 
+                "pages": {
+                    "first": "127", 
+                    "last": "132", 
+                    "range": "127\u2013132"
+                }, 
+                "publisher": {
+                    "name": [
+                        "Aldine de Gruyter"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "New York"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "New York"
+                            ]
+                        }
                     }
-                ], 
-                "full_article_title": "Associated cranial and postcranial bones of <italic>Australopithecus boisei</italic>", 
-                "publication-type": "book", 
-                "lpage": "132", 
-                "source": "Evolutionary history of the \u2018Robust\u2019 Australopithecines", 
-                "fpage": "127", 
-                "year": "1988", 
-                "position": 23, 
-                "ref": "GrauszHMLeakeyRWalkerAWardC1988Associated cranial and postcranial bones of Australopithecus boiseiGrineFEEvolutionary history of the \u2018Robust\u2019 AustralopithecinesNew YorkAldine de Gruyter127132", 
-                "id": "bib23"
+                }
             }, 
             {
-                "article_title": "Taxonomic affinity of the early Homo cranium from Swartkrans, South Africa", 
-                "lpage": "426", 
-                "doi": "10.1002/ajpa.1330920402", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Grine", 
-                        "given-names": "FE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Demes", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jungers", 
-                        "given-names": "WL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Cole", 
-                        "given-names": "TM", 
-                        "group-type": "author", 
-                        "suffix": "III"
-                    }
-                ], 
-                "full_article_title": "Taxonomic affinity of the early <italic>Homo</italic> cranium from Swartkrans, South Africa", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib24", 
+                "date": "1993", 
+                "articleTitle": "Taxonomic affinity of the early <italic>Homo</italic> cranium from Swartkrans, South Africa", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
                 "volume": "92", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/ajpa.1330920402", 
-                "fpage": "411", 
-                "year": "1993", 
-                "position": 24, 
-                "ref": "GrineFEDemesBJungersWLColeTMIII1993Taxonomic affinity of the early Homo cranium from Swartkrans, South AfricaAmerican Journal of Physical Anthropology9241142610.1002/ajpa.1330920402", 
-                "id": "bib24"
+                "pages": {
+                    "first": "411", 
+                    "last": "426", 
+                    "range": "411\u2013426"
+                }, 
+                "doi": "10.1002/ajpa.1330920402"
             }, 
             {
-                "article_title": "Fossil Homo femur from Berg Aukas, northern Namibia", 
-                "lpage": "185", 
-                "doi": "10.1002/ajpa.1330970207", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Grine", 
-                        "given-names": "FE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jungers", 
-                        "given-names": "WL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tobias", 
-                        "given-names": "PV", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Pearson", 
-                        "given-names": "OM", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Fossil <italic>Homo</italic> femur from Berg Aukas, northern Namibia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib25", 
+                "date": "1995", 
+                "articleTitle": "Fossil <italic>Homo</italic> femur from Berg Aukas, northern Namibia", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
                 "volume": "97", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/ajpa.1330970207", 
-                "fpage": "151", 
-                "year": "1995", 
-                "position": 25, 
-                "ref": "GrineFEJungersWLTobiasPVPearsonOM1995Fossil Homo femur from Berg Aukas, northern NamibiaAmerican Journal of Physical Anthropology9715118510.1002/ajpa.1330970207", 
-                "id": "bib25"
+                "pages": {
+                    "first": "151", 
+                    "last": "185", 
+                    "range": "151\u2013185"
+                }, 
+                "doi": "10.1002/ajpa.1330970207"
             }, 
             {
-                "article_title": "Phenetic affinities among early Homo crania from East and South Africa", 
-                "doi": "10.1006/jhev.1996.0019", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Grine", 
-                        "given-names": "FE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jungers", 
-                        "given-names": "WL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Schultz", 
-                        "given-names": "J", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Phenetic affinities among early <italic>Homo crania</italic> from East and South Africa", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib26", 
+                "date": "1996", 
+                "articleTitle": "Phenetic affinities among early <italic>Homo crania</italic> from East and South Africa", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "30", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1006/jhev.1996.0019", 
-                "fpage": "189", 
-                "year": "1996", 
-                "position": 26, 
-                "ref": "GrineFEJungersWLSchultzJ1996Phenetic affinities among early Homo crania from East and South AfricaJournal of Human Evolution3018910.1006/jhev.1996.0019", 
-                "id": "bib26"
+                "pages": "189", 
+                "doi": "10.1006/jhev.1996.0019"
             }, 
             {
-                "article_title": "An early Australopithecus afarensis postcranium from Woranso-Mille, Ethiopia", 
-                "lpage": "12126", 
-                "doi": "10.1073/pnas.1004527107", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Haile-Selassie", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Latimer", 
-                        "given-names": "BM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Alene", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Deino", 
-                        "given-names": "AL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Gibert", 
-                        "given-names": "L", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Melillo", 
-                        "given-names": "SM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Saylor", 
-                        "given-names": "BZ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Scott", 
-                        "given-names": "GR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Lovejoy", 
-                        "given-names": "CO", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "An early <italic>Australopithecus afarensis</italic> postcranium from Woranso-Mille, Ethiopia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib27", 
+                "date": "2010", 
+                "articleTitle": "An early <italic>Australopithecus afarensis</italic> postcranium from Woranso-Mille, Ethiopia", 
+                "journal": {
+                    "name": [
+                        "Proceedings of the National Academy of Sciences of USA"
+                    ]
+                }, 
                 "volume": "107", 
-                "source": "Proceedings of the National Academy of Sciences of USA", 
-                "reference_id": "10.1073/pnas.1004527107", 
-                "fpage": "12121", 
-                "year": "2010", 
-                "position": 27, 
-                "ref": "Haile-SelassieYLatimerBMAleneMDeinoALGibertLMelilloSMSaylorBZScottGRLovejoyCO2010An early Australopithecus afarensis postcranium from Woranso-Mille, EthiopiaProceedings of the National Academy of Sciences of USA107121211212610.1073/pnas.1004527107", 
-                "id": "bib27"
+                "pages": {
+                    "first": "12121", 
+                    "last": "12126", 
+                    "range": "12121\u201312126"
+                }, 
+                "doi": "10.1073/pnas.1004527107"
             }, 
             {
-                "article_title": "The foot of Homo naledi", 
-                "doi": "10.1038/ncomms9432", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Harcourt-Smith", 
-                        "given-names": "WEH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Throckmorton", 
-                        "given-names": "Z", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Congdon", 
-                        "given-names": "KA", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Zipfel", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Deane", 
-                        "given-names": "AS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": " Drapeau", 
-                        "given-names": "MSM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "DeSilva", 
-                        "given-names": "JM", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The foot of <italic>Homo naledi</italic>", 
-                "publication-type": "other", 
-                "volume": "6", 
+                "type": "other", 
+                "id": "bib28", 
+                "date": "2015", 
                 "source": "Nature Communications", 
-                "reference_id": "10.1038/ncomms9432", 
-                "fpage": "8432", 
-                "year": "2015", 
-                "position": 28, 
-                "ref": "Harcourt-SmithWEHThrockmortonZCongdonKAZipfelBDeaneAS DrapeauMSMChurchillSEBergerLRDeSilvaJM2015The foot of Homo nalediNature Communications6843210.1038/ncomms9432", 
-                "id": "bib28"
+                "volume": "6", 
+                "pages": "8432", 
+                "doi": "10.1038/ncomms9432"
             }, 
             {
-                "article_title": "Population bottlenecks and Pleistocene human evolution", 
-                "lpage": "22", 
-                "doi": "10.1093/oxfordjournals.molbev.a026233", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Hawks", 
-                        "given-names": "J", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hunley", 
-                        "given-names": "K", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Lee", 
-                        "given-names": "SH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Wolpoff", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Population bottlenecks and Pleistocene human evolution", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib29", 
+                "date": "2000", 
+                "articleTitle": "Population bottlenecks and Pleistocene human evolution", 
+                "journal": {
+                    "name": [
+                        "Molecular Biology and Evolution"
+                    ]
+                }, 
                 "volume": "17", 
-                "source": "Molecular Biology and Evolution", 
-                "reference_id": "10.1093/oxfordjournals.molbev.a026233", 
-                "fpage": "2", 
-                "year": "2000", 
-                "position": 29, 
-                "ref": "HawksJHunleyKLeeSHWolpoffM2000Population bottlenecks and Pleistocene human evolutionMolecular Biology and Evolution1722210.1093/oxfordjournals.molbev.a026233", 
-                "id": "bib29"
+                "pages": {
+                    "first": "2", 
+                    "last": "22", 
+                    "range": "2\u201322"
+                }, 
+                "doi": "10.1093/oxfordjournals.molbev.a026233"
             }, 
             {
-                "article_title": "Body size, body shape, and the circumscription of the genus Homo", 
-                "lpage": "S345", 
-                "doi": "10.1086/667360", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Holliday", 
-                        "given-names": "TW", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Body size, body shape, and the circumscription of the genus <italic>Homo</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib30", 
+                "date": "2012", 
+                "articleTitle": "Body size, body shape, and the circumscription of the genus <italic>Homo</italic>", 
+                "journal": {
+                    "name": [
+                        "Current Anthropology"
+                    ]
+                }, 
                 "volume": "53", 
-                "source": "Current Anthropology", 
-                "reference_id": "10.1086/667360", 
-                "fpage": "S330", 
-                "year": "2012", 
-                "position": 30, 
-                "ref": "HollidayTW2012Body size, body shape, and the circumscription of the genus HomoCurrent Anthropology53S330S34510.1086/667360", 
-                "id": "bib30"
+                "pages": {
+                    "first": "S330", 
+                    "last": "S345", 
+                    "range": "S330\u2013S345"
+                }, 
+                "doi": "10.1086/667360"
             }, 
             {
-                "article_title": "New partial skeleton of Homo habilis from Olduvai Gorge, Tanzania", 
-                "lpage": "209", 
-                "doi": "10.1038/327205a0", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Johanson", 
-                        "given-names": "DC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Masao", 
-                        "given-names": "FT", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Eck", 
-                        "given-names": "GG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "White", 
-                        "given-names": "TD", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Walter", 
-                        "given-names": "RC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kimbel", 
-                        "given-names": "WH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Asfaw", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Manega", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ndessokia", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Suwa", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "New partial skeleton of <italic>Homo habilis</italic> from Olduvai Gorge, Tanzania", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib31", 
+                "date": "1986", 
+                "articleTitle": "New partial skeleton of <italic>Homo habilis</italic> from Olduvai Gorge, Tanzania", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "327", 
-                "source": "Nature", 
-                "reference_id": "10.1038/327205a0", 
-                "fpage": "205", 
-                "year": "1986", 
-                "position": 31, 
-                "ref": "JohansonDCMasaoFTEckGGWhiteTDWalterRCKimbelWHAsfawBManegaPNdessokiaPSuwaG1986New partial skeleton of Homo habilis from Olduvai Gorge, TanzaniaNature32720520910.1038/327205a0", 
-                "id": "bib31"
+                "pages": {
+                    "first": "205", 
+                    "last": "209", 
+                    "range": "205\u2013209"
+                }, 
+                "doi": "10.1038/327205a0"
             }, 
             {
-                "article_title": "Pliocene hominids from the Hadar formation, Ethiopia (1973\u20131977): Stratigraphic, chronologic, and paleoenvironmental contexts, with notes on hominid morphology and systematics", 
-                "lpage": "402", 
-                "doi": "10.1002/ajpa.1330570402", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Johanson", 
-                        "given-names": "DC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Taieb", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Coppens", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Pliocene hominids from the Hadar formation, Ethiopia (1973\u20131977): Stratigraphic, chronologic, and paleoenvironmental contexts, with notes on hominid morphology and systematics", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib32", 
+                "date": "1982", 
+                "articleTitle": "Pliocene hominids from the Hadar formation, Ethiopia (1973\u20131977): Stratigraphic, chronologic, and paleoenvironmental contexts, with notes on hominid morphology and systematics", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
                 "volume": "57", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/ajpa.1330570402", 
-                "fpage": "373", 
-                "year": "1982", 
-                "position": 32, 
-                "ref": "JohansonDCTaiebMCoppensY1982Pliocene hominids from the Hadar formation, Ethiopia (1973\u20131977): Stratigraphic, chronologic, and paleoenvironmental contexts, with notes on hominid morphology and systematicsAmerican Journal of Physical Anthropology5737340210.1002/ajpa.1330570402", 
-                "id": "bib32"
+                "pages": {
+                    "first": "373", 
+                    "last": "402", 
+                    "range": "373\u2013402"
+                }, 
+                "doi": "10.1002/ajpa.1330570402"
             }, 
             {
-                "article_title": "The foot of Homo floresiensis", 
-                "lpage": "84", 
-                "doi": "10.1038/nature07989", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Jungers", 
-                        "given-names": "WL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Harcourt-Smith", 
-                        "given-names": "WE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Wunderlich", 
-                        "given-names": "RE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tocheri", 
-                        "given-names": "MW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Larson", 
-                        "given-names": "SG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sutikna", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Due", 
-                        "given-names": "RA", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Morwood", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The foot of <italic>Homo floresiensis</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib33", 
+                "date": "2009a", 
+                "articleTitle": "The foot of <italic>Homo floresiensis</italic>", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "459", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature07989", 
-                "fpage": "81", 
-                "year": "2009a", 
-                "position": 33, 
-                "ref": "JungersWLHarcourt-SmithWEWunderlichRETocheriMWLarsonSGSutiknaTDueRAMorwoodMJ2009aThe foot of Homo floresiensisNature459818410.1038/nature07989", 
-                "id": "bib33"
+                "pages": {
+                    "first": "81", 
+                    "last": "84", 
+                    "range": "81\u201384"
+                }, 
+                "doi": "10.1038/nature07989"
             }, 
             {
-                "article_title": "Descriptions of the lower limb skeleton of Homo floresiensis", 
-                "lpage": "554", 
-                "doi": "10.1016/j.jhevol.2008.08.014", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Jungers", 
-                        "given-names": "WL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Larson", 
-                        "given-names": "SG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Harcourt-Smith", 
-                        "given-names": "W", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Morwood", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sutikna", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Awe", 
-                        "given-names": "RD", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Djubiantono", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Descriptions of the lower limb skeleton of <italic>Homo floresiensis</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib34", 
+                "date": "2009b", 
+                "articleTitle": "Descriptions of the lower limb skeleton of <italic>Homo floresiensis</italic>", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "57", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1016/j.jhevol.2008.08.014", 
-                "fpage": "538", 
-                "year": "2009b", 
-                "position": 34, 
-                "ref": "JungersWLLarsonSGHarcourt-SmithWMorwoodMJSutiknaTAweRDDjubiantonoT2009bDescriptions of the lower limb skeleton of Homo floresiensisJournal of Human Evolution5753855410.1016/j.jhevol.2008.08.014", 
-                "id": "bib34"
+                "pages": {
+                    "first": "538", 
+                    "last": "554", 
+                    "range": "538\u2013554"
+                }, 
+                "doi": "10.1016/j.jhevol.2008.08.014"
             }, 
             {
-                "article_title": "The Drimolen skull: the most complete australopithecine cranium and mandible to date", 
-                "lpage": "192", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Keyser", 
-                        "given-names": "AW", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The Drimolen skull: the most complete australopithecine cranium and mandible to date", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib35", 
+                "date": "2000", 
+                "articleTitle": "The Drimolen skull: the most complete australopithecine cranium and mandible to date", 
+                "journal": {
+                    "name": [
+                        "South African Journal of Science"
+                    ]
+                }, 
                 "volume": "96", 
-                "source": "South African Journal of Science", 
-                "fpage": "189", 
-                "year": "2000", 
-                "position": 35, 
-                "ref": "KeyserAW2000The Drimolen skull: the most complete australopithecine cranium and mandible to dateSouth African Journal of Science96189192", 
-                "id": "bib35"
+                "pages": {
+                    "first": "189", 
+                    "last": "192", 
+                    "range": "189\u2013192"
+                }
             }, 
             {
-                "article_title": "Drimolen: a new hominin-bearing site in Gauteng, South Africa", 
-                "lpage": "197", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Keyser", 
-                        "given-names": "AW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Menter", 
-                        "given-names": "CG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Moggi-Cecchi", 
-                        "given-names": "JJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Pickering", 
-                        "given-names": "TR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Drimolen: a new hominin-bearing site in Gauteng, South Africa", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib36", 
+                "date": "2000", 
+                "articleTitle": "Drimolen: a new hominin-bearing site in Gauteng, South Africa", 
+                "journal": {
+                    "name": [
+                        "South African Journal of Science"
+                    ]
+                }, 
                 "volume": "96", 
-                "source": "South African Journal of Science", 
-                "fpage": "193", 
-                "year": "2000", 
-                "position": 36, 
-                "ref": "KeyserAWMenterCGMoggi-CecchiJJPickeringTRBergerLR2000Drimolen: a new hominin-bearing site in Gauteng, South AfricaSouth African Journal of Science96193197", 
-                "id": "bib36"
+                "pages": {
+                    "first": "193", 
+                    "last": "197", 
+                    "range": "193\u2013197"
+                }
             }, 
             {
-                "publisher_loc": "New York", 
-                "article_doi": "10.7554/eLife.09560", 
-                "publisher_name": "Oxford", 
-                "year": "2004", 
-                "publication-type": "book", 
-                "source": "The skull of Australopithecus afarensis", 
-                "authors": [
-                    {
-                        "surname": "Kimbel", 
-                        "given-names": "WH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Rak", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Johanson", 
-                        "given-names": "DC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Minugh-Purvis", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                "type": "book", 
+                "id": "bib37", 
+                "date": "2004", 
+                "bookTitle": "The skull of Australopithecus afarensis", 
+                "publisher": {
+                    "name": [
+                        "Oxford"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "New York"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "New York"
+                            ]
+                        }
                     }
-                ], 
-                "position": 37, 
-                "ref": "KimbelWHRakYJohansonDCMinugh-PurvisN2004The skull of Australopithecus afarensisNew YorkOxford", 
-                "id": "bib37"
+                }
             }, 
             {
-                "article_title": "Systematic assessment of a maxilla of Homo from Hadar, Ethiopia", 
-                "lpage": "262", 
-                "doi": "10.1002/(SICI)1096-8644(199706)103:2<235::AID-AJPA8>3.0.CO;2-S", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Kimbel", 
-                        "given-names": "WH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Johanson", 
-                        "given-names": "DC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Rak", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Systematic assessment of a maxilla of Homo from Hadar, Ethiopia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib38", 
+                "date": "1997", 
+                "articleTitle": "Systematic assessment of a maxilla of Homo from Hadar, Ethiopia", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
                 "volume": "103", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/(SICI)1096-8644(199706)103:2<235::AID-AJPA8>3.0.CO;2-S", 
-                "fpage": "235", 
-                "year": "1997", 
-                "position": 38, 
-                "ref": "KimbelWHJohansonDCRakY1997Systematic assessment of a maxilla of Homo from Hadar, EthiopiaAmerican Journal of Physical Anthropology10323526210.1002/(SICI)1096-8644(199706)103:2<235::AID-AJPA8>3.0.CO;2-S", 
-                "id": "bib38"
+                "pages": {
+                    "first": "235", 
+                    "last": "262", 
+                    "range": "235\u2013262"
+                }, 
+                "doi": "10.1002/(SICI)1096-8644(199706)103:2<235::AID-AJPA8>3.0.CO;2-S"
             }, 
             {
-                "article_title": "Australopithecus sediba hand demonstrates mosaic evolution of locomotor and manipulative abilities", 
-                "lpage": "1417", 
-                "doi": "10.1126/science.1202625", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Kivell", 
-                        "given-names": "TL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kibii", 
-                        "given-names": "JM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Schmid", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "<italic>Australopithecus sediba</italic> hand demonstrates mosaic evolution of locomotor and manipulative abilities", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib39", 
+                "date": "2011", 
+                "articleTitle": "<italic>Australopithecus sediba</italic> hand demonstrates mosaic evolution of locomotor and manipulative abilities", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "333", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1202625", 
-                "fpage": "1411", 
-                "year": "2011", 
-                "position": 39, 
-                "ref": "KivellTLKibiiJMChurchillSESchmidPBergerLR2011Australopithecus sediba hand demonstrates mosaic evolution of locomotor and manipulative abilitiesScience3331411141710.1126/science.1202625", 
-                "id": "bib39"
+                "pages": {
+                    "first": "1411", 
+                    "last": "1417", 
+                    "range": "1411\u20131417"
+                }, 
+                "doi": "10.1126/science.1202625"
             }, 
             {
-                "article_title": "The hand of Homo naledi", 
-                "doi": "10.1038/ncomms9431", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Kivell", 
-                        "given-names": "TL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Deane", 
-                        "given-names": "AS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tocheri", 
-                        "given-names": "MW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Orr", 
-                        "given-names": "CM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Schmid", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hawks", 
-                        "given-names": "J", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The hand of <italic>Homo naledi</italic>", 
-                "publication-type": "other", 
-                "volume": "6", 
+                "type": "other", 
+                "id": "bib40", 
+                "date": "2015", 
                 "source": "Nature Communications", 
-                "reference_id": "10.1038/ncomms9431", 
-                "fpage": "8431", 
-                "year": "2015", 
-                "position": 40, 
-                "ref": "KivellTLDeaneASTocheriMWOrrCMSchmidPHawksJBergerLRChurchillSE2015The hand of Homo nalediNature Communications6843110.1038/ncomms9431", 
-                "id": "bib40"
+                "volume": "6", 
+                "pages": "8431", 
+                "doi": "10.1038/ncomms9431"
             }, 
             {
-                "article_title": "New fossils from Koobi Fora in northern Kenya confirm taxonomic diversity in early Homo", 
-                "lpage": "204", 
-                "doi": "10.1038/nature11322", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Leakey", 
-                        "given-names": "MG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Spoor", 
-                        "given-names": "F", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Dean", 
-                        "given-names": "MC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Feibel", 
-                        "given-names": "CS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ant\u00f3n", 
-                        "given-names": "SC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kiarie", 
-                        "given-names": "C", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Leakey", 
-                        "given-names": "LN", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "New fossils from Koobi Fora in northern Kenya confirm taxonomic diversity in early Homo", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib41", 
+                "date": "2012", 
+                "articleTitle": "New fossils from Koobi Fora in northern Kenya confirm taxonomic diversity in early Homo", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "488", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature11322", 
-                "fpage": "201", 
-                "year": "2012", 
-                "position": 41, 
-                "ref": "LeakeyMGSpoorFDeanMCFeibelCSAnt\u00f3nSCKiarieCLeakeyLN2012New fossils from Koobi Fora in northern Kenya confirm taxonomic diversity in early HomoNature48820120410.1038/nature11322", 
-                "id": "bib41"
+                "pages": {
+                    "first": "201", 
+                    "last": "204", 
+                    "range": "201\u2013204"
+                }, 
+                "doi": "10.1038/nature11322"
             }, 
             {
-                "article_title": "Assigned resampling method: a new method to estimate size sexual dimorphism in samples of unknown sex", 
-                "lpage": "39", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Lee", 
-                        "given-names": "SH", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Assigned resampling method: a new method to estimate size sexual dimorphism in samples of unknown sex", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib42", 
+                "date": "2001", 
+                "articleTitle": "Assigned resampling method: a new method to estimate size sexual dimorphism in samples of unknown sex", 
+                "journal": {
+                    "name": [
+                        "Przegla\u0328d Antropologiczny Anthropological Review"
+                    ]
+                }, 
                 "volume": "64", 
-                "source": "Przegla\u0328d Antropologiczny Anthropological Review", 
-                "fpage": "21", 
-                "year": "2001", 
-                "position": 42, 
-                "ref": "LeeSH2001Assigned resampling method: a new method to estimate size sexual dimorphism in samples of unknown sexPrzegla\u0328d Antropologiczny Anthropological Review642139", 
-                "id": "bib42"
+                "pages": {
+                    "first": "21", 
+                    "last": "39", 
+                    "range": "21\u201339"
+                }
             }, 
             {
-                "article_title": "Postcranial evidence from early Homo from Dmanisi, Georgia", 
-                "lpage": "310", 
-                "doi": "10.1038/nature06134", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Lordkipanidze", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jashashvili", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Vekua", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ponce de Le\u00f3n", 
-                        "given-names": "MS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Zollikofer", 
-                        "given-names": "CP", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Rightmire", 
-                        "given-names": "GP", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Pontzer", 
-                        "given-names": "H", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ferring", 
-                        "given-names": "R", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Oms", 
-                        "given-names": "O", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tappen", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Bukhsianidze", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Agusti", 
-                        "given-names": "J", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kahlke", 
-                        "given-names": "R", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kiladze", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Martinez-Navarro", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Mouskhelishvili", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Nioradze", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Rook", 
-                        "given-names": "L", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Postcranial evidence from early <italic>Homo</italic> from Dmanisi, Georgia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib43", 
+                "date": "2007", 
+                "articleTitle": "Postcranial evidence from early <italic>Homo</italic> from Dmanisi, Georgia", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "449", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature06134", 
-                "fpage": "305", 
-                "year": "2007", 
-                "position": 43, 
-                "ref": "LordkipanidzeDJashashviliTVekuaAPonce de Le\u00f3nMSZollikoferCPRightmireGPPontzerHFerringROmsOTappenMBukhsianidzeMAgustiJKahlkeRKiladzeGMartinez-NavarroBMouskhelishviliANioradzeMRookL2007Postcranial evidence from early Homo from Dmanisi, GeorgiaNature44930531010.1038/nature06134", 
-                "id": "bib43"
+                "pages": {
+                    "first": "305", 
+                    "last": "310", 
+                    "range": "305\u2013310"
+                }, 
+                "doi": "10.1038/nature06134"
             }, 
             {
-                "article_title": "A complete skull from Dmanisi, Georgia, and the evolutionary biology of early Homo", 
-                "lpage": "331", 
-                "doi": "10.1126/science.1238484", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Lordkipanidze", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ponce de Le\u00f3n", 
-                        "given-names": "MS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Margvelashvili", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Rak", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Rightmire", 
-                        "given-names": "GP", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Vekua", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Zollikofer", 
-                        "given-names": "CP", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "A complete skull from Dmanisi, Georgia, and the evolutionary biology of early <italic>Homo</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib44", 
+                "date": "2013", 
+                "articleTitle": "A complete skull from Dmanisi, Georgia, and the evolutionary biology of early <italic>Homo</italic>", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "342", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1238484", 
-                "fpage": "326", 
-                "year": "2013", 
-                "position": 44, 
-                "ref": "LordkipanidzeDPonce de Le\u00f3nMSMargvelashviliARakYRightmireGPVekuaAZollikoferCP2013A complete skull from Dmanisi, Georgia, and the evolutionary biology of early HomoScience34232633110.1126/science.1238484", 
-                "id": "bib44"
+                "pages": {
+                    "first": "326", 
+                    "last": "331", 
+                    "range": "326\u2013331"
+                }, 
+                "doi": "10.1126/science.1238484"
             }, 
             {
-                "article_title": "How humans differ from other animals in their levels of morphological variation", 
-                "doi": "10.1371/journal.pone.0006876", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "McKellar", 
-                        "given-names": "AE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hendry", 
-                        "given-names": "AP", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "How humans differ from other animals in their levels of morphological variation", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib45", 
+                "date": "2009", 
+                "articleTitle": "How humans differ from other animals in their levels of morphological variation", 
+                "journal": {
+                    "name": [
+                        "PLOS ONE"
+                    ]
+                }, 
                 "volume": "4", 
-                "source": "PLOS ONE", 
-                "reference_id": "10.1371/journal.pone.0006876", 
-                "fpage": "e6876", 
-                "year": "2009", 
-                "position": 45, 
-                "ref": "McKellarAEHendryAP2009How humans differ from other animals in their levels of morphological variationPLOS ONE4e687610.1371/journal.pone.0006876", 
-                "id": "bib45"
+                "pages": "e6876", 
+                "doi": "10.1371/journal.pone.0006876"
             }, 
             {
-                "article_title": "Further evidence for small-bodied hominins from the Late Pleistocene of Flores, Indonesia", 
-                "lpage": "1017", 
-                "doi": "10.1038/nature04022", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Morwood", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Brown", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sutikna", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Saptomo", 
-                        "given-names": "EW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Westaway", 
-                        "given-names": "KE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Due", 
-                        "given-names": "RA", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Roberts", 
-                        "given-names": "RG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Maeda", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Wasisto", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Djubiantono", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Further evidence for small-bodied hominins from the Late Pleistocene of Flores, Indonesia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib46", 
+                "date": "2005", 
+                "articleTitle": "Further evidence for small-bodied hominins from the Late Pleistocene of Flores, Indonesia", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "437", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature04022", 
-                "fpage": "1012", 
-                "year": "2005", 
-                "position": 46, 
-                "ref": "MorwoodMJBrownPSutiknaTSaptomoEWWestawayKEDueRARobertsRGMaedaTWasistoSDjubiantonoT2005Further evidence for small-bodied hominins from the Late Pleistocene of Flores, IndonesiaNature4371012101710.1038/nature04022", 
-                "id": "bib46"
+                "pages": {
+                    "first": "1012", 
+                    "last": "1017", 
+                    "range": "1012\u20131017"
+                }, 
+                "doi": "10.1038/nature04022"
             }, 
             {
-                "article_title": "New wrist bones for Homo floresiensis from liang bua (Flores, Indonesia)", 
-                "lpage": "129", 
-                "doi": "10.1016/j.jhevol.2012.10.003", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Orr", 
-                        "given-names": "CM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tocheri", 
-                        "given-names": "MW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Burnett", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Awe", 
-                        "given-names": "RD", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Saptomo", 
-                        "given-names": "EW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sutikna", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jatmiko", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Wasisto", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Morwood", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jungers", 
-                        "given-names": "WL", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "New wrist bones for <italic>Homo floresiensis</italic> from liang bua (Flores, Indonesia)", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib47", 
+                "date": "2013", 
+                "articleTitle": "New wrist bones for <italic>Homo floresiensis</italic> from liang bua (Flores, Indonesia)", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "64", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1016/j.jhevol.2012.10.003", 
-                "fpage": "109", 
-                "year": "2013", 
-                "position": 47, 
-                "ref": "OrrCMTocheriMWBurnettSEAweRDSaptomoEWSutiknaTJatmikoWasistoSMorwoodMJJungersWL2013New wrist bones for Homo floresiensis from liang bua (Flores, Indonesia)Journal of Human Evolution6410912910.1016/j.jhevol.2012.10.003", 
-                "id": "bib47"
+                "pages": {
+                    "first": "109", 
+                    "last": "129", 
+                    "range": "109\u2013129"
+                }, 
+                "doi": "10.1016/j.jhevol.2012.10.003"
             }, 
             {
-                "article_title": "Revision of the fully technique for estimating statures", 
-                "lpage": "384", 
-                "doi": "10.1002/ajpa.20361", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Raxter", 
-                        "given-names": "MH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Auerbach", 
-                        "given-names": "BM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ruff", 
-                        "given-names": "CB", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Revision of the fully technique for estimating statures", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib48", 
+                "date": "2006", 
+                "articleTitle": "Revision of the fully technique for estimating statures", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
                 "volume": "130", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/ajpa.20361", 
-                "fpage": "374", 
-                "year": "2006", 
-                "position": 48, 
-                "ref": "RaxterMHAuerbachBMRuffCB2006Revision of the fully technique for estimating staturesAmerican Journal of Physical Anthropology13037438410.1002/ajpa.20361", 
-                "id": "bib48"
+                "pages": {
+                    "first": "374", 
+                    "last": "384", 
+                    "range": "374\u2013384"
+                }, 
+                "doi": "10.1002/ajpa.20361"
             }, 
             {
-                "article_title": "Anatomical descriptions, comparative studies and evolutionary significance of the hominin skulls from Dmanisi, Republic of Georgia", 
-                "lpage": "141", 
-                "doi": "10.1016/j.jhevol.2005.07.009", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Rightmire", 
-                        "given-names": "GP", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Lordkipadnize", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Vekua", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Anatomical descriptions, comparative studies and evolutionary significance of the hominin skulls from Dmanisi, Republic of Georgia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib49", 
+                "date": "2006", 
+                "articleTitle": "Anatomical descriptions, comparative studies and evolutionary significance of the hominin skulls from Dmanisi, Republic of Georgia", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "50", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1016/j.jhevol.2005.07.009", 
-                "fpage": "115", 
-                "year": "2006", 
-                "position": 49, 
-                "ref": "RightmireGPLordkipadnizeDVekuaA2006Anatomical descriptions, comparative studies and evolutionary significance of the hominin skulls from Dmanisi, Republic of GeorgiaJournal of Human Evolution5011514110.1016/j.jhevol.2005.07.009", 
-                "id": "bib49"
+                "pages": {
+                    "first": "115", 
+                    "last": "141", 
+                    "range": "115\u2013141"
+                }, 
+                "doi": "10.1016/j.jhevol.2005.07.009"
             }, 
             {
-                "article_title": "Reassessing manual proportions in Australopithecus afarensis", 
-                "lpage": "406", 
-                "doi": "10.1002/ajpa.22365", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Rolian", 
-                        "given-names": "C", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Gordon", 
-                        "given-names": "AD", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Reassessing manual proportions in <italic>Australopithecus afarensis</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib50", 
+                "date": "2013", 
+                "articleTitle": "Reassessing manual proportions in <italic>Australopithecus afarensis</italic>", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
                 "volume": "152", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/ajpa.22365", 
-                "fpage": "393", 
-                "year": "2013", 
-                "position": 50, 
-                "ref": "RolianCGordonAD2013Reassessing manual proportions in Australopithecus afarensisAmerican Journal of Physical Anthropology15239340610.1002/ajpa.22365", 
-                "id": "bib50"
+                "pages": {
+                    "first": "393", 
+                    "last": "406", 
+                    "range": "393\u2013406"
+                }, 
+                "doi": "10.1002/ajpa.22365"
             }, 
             {
-                "article_title": "Body mass and encephalization in Pleistocene Homo", 
-                "lpage": "176", 
-                "doi": "10.1038/387173a0", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Ruff", 
-                        "given-names": "CB", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Trinkaus", 
-                        "given-names": "E", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Holliday", 
-                        "given-names": "TW", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Body mass and encephalization in Pleistocene <italic>Homo</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib51", 
+                "date": "1997", 
+                "articleTitle": "Body mass and encephalization in Pleistocene <italic>Homo</italic>", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "387", 
-                "source": "Nature", 
-                "reference_id": "10.1038/387173a0", 
-                "fpage": "173", 
-                "year": "1997", 
-                "position": 51, 
-                "ref": "RuffCBTrinkausEHollidayTW1997Body mass and encephalization in Pleistocene HomoNature38717317610.1038/387173a0", 
-                "id": "bib51"
+                "pages": {
+                    "first": "173", 
+                    "last": "176", 
+                    "range": "173\u2013176"
+                }, 
+                "doi": "10.1038/387173a0"
             }, 
             {
-                "article_title": "Mosaic morphology in the thorax of Australopithecus sediba", 
-                "doi": "10.1126/science.1234598", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Schmid", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Nalla", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Weissen", 
-                        "given-names": "E", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Carlson", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "de Ruiter", 
-                        "given-names": "DJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Mosaic morphology in the thorax of <italic>Australopithecus sediba</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib52", 
+                "date": "2013", 
+                "articleTitle": "Mosaic morphology in the thorax of <italic>Australopithecus sediba</italic>", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "340", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1234598", 
-                "fpage": "1234598", 
-                "year": "2013", 
-                "position": 52, 
-                "ref": "SchmidPChurchillSENallaSWeissenECarlsonKJde RuiterDJBergerLR2013Mosaic morphology in the thorax of Australopithecus sedibaScience340123459810.1126/science.1234598", 
-                "id": "bib52"
+                "pages": "1234598", 
+                "doi": "10.1126/science.1234598"
             }, 
             {
-                "article_title": "Oldest Homo and Pliocene biogeography of the Malawi rift", 
-                "lpage": "836", 
-                "doi": "10.1038/365833a0", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Schrenk", 
-                        "given-names": "F", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Bromage", 
-                        "given-names": "TG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Betzler", 
-                        "given-names": "CG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ring", 
-                        "given-names": "U", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Juwayeyi", 
-                        "given-names": "YM", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Oldest <italic>Homo</italic> and Pliocene biogeography of the Malawi rift", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib53", 
+                "date": "1993", 
+                "articleTitle": "Oldest <italic>Homo</italic> and Pliocene biogeography of the Malawi rift", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "365", 
-                "source": "Nature", 
-                "reference_id": "10.1038/365833a0", 
-                "fpage": "833", 
-                "year": "1993", 
-                "position": 53, 
-                "ref": "SchrenkFBromageTGBetzlerCGRingUJuwayeyiYM1993Oldest Homo and Pliocene biogeography of the Malawi riftNature36583383610.1038/365833a0", 
-                "id": "bib53"
+                "pages": {
+                    "first": "833", 
+                    "last": "836", 
+                    "range": "833\u2013836"
+                }, 
+                "doi": "10.1038/365833a0"
             }, 
             {
-                "article_title": "Implications of new early Homo fossils from Ileret, east of Lake Turkana, Kenya", 
-                "lpage": "691", 
-                "doi": "10.1038/nature05986", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Spoor", 
-                        "given-names": "F", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Leakey", 
-                        "given-names": "MG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Gathogo", 
-                        "given-names": "PN", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Brown", 
-                        "given-names": "FH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ant\u00f3n", 
-                        "given-names": "SC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "McDougall", 
-                        "given-names": "I", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kiarie", 
-                        "given-names": "C", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Manthi", 
-                        "given-names": "FK", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Leakey", 
-                        "given-names": "LN", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Implications of new early <italic>Homo</italic> fossils from Ileret, east of Lake Turkana, Kenya", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib55", 
+                "date": "2007", 
+                "articleTitle": "Implications of new early <italic>Homo</italic> fossils from Ileret, east of Lake Turkana, Kenya", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "448", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature05986", 
-                "fpage": "688", 
-                "year": "2007", 
-                "position": 54, 
-                "ref": "SpoorFLeakeyMGGathogoPNBrownFHAnt\u00f3nSCMcDougallIKiarieCManthiFKLeakeyLN2007Implications of new early Homo fossils from Ileret, east of Lake Turkana, KenyaNature44868869110.1038/nature05986", 
-                "id": "bib55"
+                "pages": {
+                    "first": "688", 
+                    "last": "691", 
+                    "range": "688\u2013691"
+                }, 
+                "doi": "10.1038/nature05986"
             }, 
             {
-                "article_title": "The skeletal phenotype of \u2018Negritos\u2019 from the Andaman Islands and Philippines relative to global variation among hunter-gatherers", 
-                "lpage": "94", 
-                "doi": "10.3378/027.085.0304", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Stock", 
-                        "given-names": "JT", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The skeletal phenotype of \u2018Negritos\u2019 from the Andaman Islands and Philippines relative to global variation among hunter-gatherers", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib56", 
+                "date": "2013", 
+                "articleTitle": "The skeletal phenotype of \u2018Negritos\u2019 from the Andaman Islands and Philippines relative to global variation among hunter-gatherers", 
+                "journal": {
+                    "name": [
+                        "Human Biology"
+                    ]
+                }, 
                 "volume": "85", 
-                "source": "Human Biology", 
-                "reference_id": "10.3378/027.085.0304", 
-                "fpage": "67", 
-                "year": "2013", 
-                "position": 55, 
-                "ref": "StockJT2013The skeletal phenotype of \u2018Negritos\u2019 from the Andaman Islands and Philippines relative to global variation among hunter-gatherersHuman Biology85679410.3378/027.085.0304", 
-                "id": "bib56"
+                "pages": {
+                    "first": "67", 
+                    "last": "94", 
+                    "range": "67\u201394"
+                }, 
+                "doi": "10.3378/027.085.0304"
             }, 
             {
-                "article_title": "Hand of Paranthropus robustus from Member 1, Swartkrans: fossil evidence for tool behavior", 
-                "lpage": "784", 
-                "doi": "10.1126/science.3129783", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Susman", 
-                        "given-names": "RL", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Hand of <italic>Paranthropus robustus</italic> from Member 1, Swartkrans: fossil evidence for tool behavior", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib57", 
+                "date": "1988", 
+                "articleTitle": "Hand of <italic>Paranthropus robustus</italic> from Member 1, Swartkrans: fossil evidence for tool behavior", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "240", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.3129783", 
-                "fpage": "781", 
-                "year": "1988", 
-                "position": 56, 
-                "ref": "SusmanRL1988Hand of Paranthropus robustus from Member 1, Swartkrans: fossil evidence for tool behaviorScience24078178410.1126/science.3129783", 
-                "id": "bib57"
+                "pages": {
+                    "first": "781", 
+                    "last": "784", 
+                    "range": "781\u2013784"
+                }, 
+                "doi": "10.1126/science.3129783"
             }, 
             {
-                "article_title": "Recently identified postcranial remains of Paranthropus and early Homo from Swartkrans Cave, South Africa", 
-                "lpage": "629", 
-                "doi": "10.1006/jhev.2001.0510", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Susman", 
-                        "given-names": "RL", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "de Ruiter", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Brain", 
-                        "given-names": "CK", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Recently identified postcranial remains of <italic>Paranthropus</italic> and early <italic>Homo</italic> from Swartkrans Cave, South Africa", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib58", 
+                "date": "2001", 
+                "articleTitle": "Recently identified postcranial remains of <italic>Paranthropus</italic> and early <italic>Homo</italic> from Swartkrans Cave, South Africa", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "41", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1006/jhev.2001.0510", 
-                "fpage": "607", 
-                "year": "2001", 
-                "position": 57, 
-                "ref": "SusmanRLde RuiterDBrainCK2001Recently identified postcranial remains of Paranthropus and early Homo from Swartkrans Cave, South AfricaJournal of Human Evolution4160762910.1006/jhev.2001.0510", 
-                "id": "bib58"
+                "pages": {
+                    "first": "607", 
+                    "last": "629", 
+                    "range": "607\u2013629"
+                }, 
+                "doi": "10.1006/jhev.2001.0510"
             }, 
             {
-                "article_title": "The first skull of Australopithecus boisei", 
-                "lpage": "492", 
-                "doi": "10.1038/39037", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Suwa", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Asfaw", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Beyene", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "White", 
-                        "given-names": "TD", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Katoh", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Nagaoka", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Nakaya", 
-                        "given-names": "H", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Uzawa", 
-                        "given-names": "K", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Renne", 
-                        "given-names": "P", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "WoldeGabriel", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The first skull of <italic>Australopithecus boisei</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib59", 
+                "date": "1997", 
+                "articleTitle": "The first skull of <italic>Australopithecus boisei</italic>", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "389", 
-                "source": "Nature", 
-                "reference_id": "10.1038/39037", 
-                "fpage": "489", 
-                "year": "1997", 
-                "position": 58, 
-                "ref": "SuwaGAsfawBBeyeneYWhiteTDKatohSNagaokaSNakayaHUzawaKRennePWoldeGabrielG1997The first skull of Australopithecus boiseiNature38948949210.1038/39037", 
-                "id": "bib59"
+                "pages": {
+                    "first": "489", 
+                    "last": "492", 
+                    "range": "489\u2013492"
+                }, 
+                "doi": "10.1038/39037"
             }, 
             {
-                "article_title": "Mandibular postcanine dentition from the Shungura formation, Ethiopia: crown morphology, taxonomic allocations, and Plio-Pleistocene hominid evolution", 
-                "lpage": "282", 
-                "doi": "10.1002/(SICI)1096-8644(199610)101:2<247::AID-AJPA9>3.0.CO;2-Z", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Suwa", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "White", 
-                        "given-names": "TD", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Howell", 
-                        "given-names": "FC", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Mandibular postcanine dentition from the Shungura formation, Ethiopia: crown morphology, taxonomic allocations, and Plio-Pleistocene hominid evolution", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib60", 
+                "date": "1996", 
+                "articleTitle": "Mandibular postcanine dentition from the Shungura formation, Ethiopia: crown morphology, taxonomic allocations, and Plio-Pleistocene hominid evolution", 
+                "journal": {
+                    "name": [
+                        "American Journal of Physical Anthropology"
+                    ]
+                }, 
                 "volume": "101", 
-                "source": "American Journal of Physical Anthropology", 
-                "reference_id": "10.1002/(SICI)1096-8644(199610)101:2<247::AID-AJPA9>3.0.CO;2-Z", 
-                "fpage": "247", 
-                "year": "1996", 
-                "position": 59, 
-                "ref": "SuwaGWhiteTDHowellFC1996Mandibular postcanine dentition from the Shungura formation, Ethiopia: crown morphology, taxonomic allocations, and Plio-Pleistocene hominid evolutionAmerican Journal of Physical Anthropology10124728210.1002/(SICI)1096-8644(199610)101:2<247::AID-AJPA9>3.0.CO;2-Z", 
-                "id": "bib60"
+                "pages": {
+                    "first": "247", 
+                    "last": "282", 
+                    "range": "247\u2013282"
+                }, 
+                "doi": "10.1002/(SICI)1096-8644(199610)101:2<247::AID-AJPA9>3.0.CO;2-Z"
             }, 
             {
-                "article_title": "Early pleistocene Homo erectus fossils from konso, southern Ethiopia", 
-                "lpage": "151", 
-                "doi": "10.1537/ase.061203", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Suwa", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Asfaw", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Haile-Selassie", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "White", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Katoh", 
-                        "given-names": "S", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Woldegabriel", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Hart", 
-                        "given-names": "WK", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Nakaya", 
-                        "given-names": "H", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Beyene", 
-                        "given-names": "Y", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Early pleistocene <italic>Homo erectus</italic> fossils from konso, southern Ethiopia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib61", 
+                "date": "2007", 
+                "articleTitle": "Early pleistocene <italic>Homo erectus</italic> fossils from konso, southern Ethiopia", 
+                "journal": {
+                    "name": [
+                        "Anthropological Science"
+                    ]
+                }, 
                 "volume": "115", 
-                "source": "Anthropological Science", 
-                "reference_id": "10.1537/ase.061203", 
-                "fpage": "133", 
-                "year": "2007", 
-                "position": 60, 
-                "ref": "SuwaGAsfawBHaile-SelassieYWhiteTKatohSWoldegabrielGHartWKNakayaHBeyeneY2007Early pleistocene Homo erectus fossils from konso, southern EthiopiaAnthropological Science11513315110.1537/ase.061203", 
-                "id": "bib61"
+                "pages": {
+                    "first": "133", 
+                    "last": "151", 
+                    "range": "133\u2013151"
+                }, 
+                "doi": "10.1537/ase.061203"
             }, 
             {
-                "publisher_loc": "Cambridge", 
-                "article_doi": "10.7554/eLife.09560", 
-                "publisher_name": "Cambridge University Press", 
-                "year": "1967", 
-                "publication-type": "book", 
-                "source": "The cranium and maxillary dentition of Australopithecus (Zinjanthropus) boisei", 
-                "authors": [
-                    {
-                        "surname": "Tobias", 
-                        "given-names": "PV", 
-                        "group-type": "author"
+                "type": "book", 
+                "id": "bib62", 
+                "date": "1967", 
+                "bookTitle": "The cranium and maxillary dentition of Australopithecus (Zinjanthropus) boisei", 
+                "publisher": {
+                    "name": [
+                        "Cambridge University Press"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Cambridge"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Cambridge"
+                            ]
+                        }
                     }
-                ], 
-                "position": 61, 
-                "ref": "TobiasPV1967The cranium and maxillary dentition of Australopithecus (Zinjanthropus) boiseiCambridgeCambridge University Press", 
-                "id": "bib62"
+                }
             }, 
             {
-                "publisher_loc": "Cambridge", 
-                "article_doi": "10.7554/eLife.09560", 
-                "publisher_name": "Cambridge University Press", 
-                "year": "1991", 
-                "publication-type": "book", 
-                "source": "Olduvai Gorge volume 4: the skulls, endocasts and teeth of Homo habilis", 
-                "authors": [
-                    {
-                        "surname": "Tobias", 
-                        "given-names": "PV", 
-                        "group-type": "author"
+                "type": "book", 
+                "id": "bib63", 
+                "date": "1991", 
+                "bookTitle": "Olduvai Gorge volume 4: the skulls, endocasts and teeth of Homo habilis", 
+                "publisher": {
+                    "name": [
+                        "Cambridge University Press"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Cambridge"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Cambridge"
+                            ]
+                        }
                     }
-                ], 
-                "position": 62, 
-                "ref": "TobiasPV1991Olduvai Gorge volume 4: the skulls, endocasts and teeth of Homo habilisCambridgeCambridge University Press", 
-                "id": "bib63"
+                }
             }, 
             {
-                "article_title": "The primitive wrist of Homo floresiensis and its implicatiosn for hominin evolution", 
-                "lpage": "1745", 
-                "doi": "10.1126/science.1147143", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Tocheri", 
-                        "given-names": "MW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Orr", 
-                        "given-names": "CM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Larson", 
-                        "given-names": "SG", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Sutikna", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jatmiko", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Saptomo", 
-                        "given-names": "EW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Due", 
-                        "given-names": "RA", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Djubiantono", 
-                        "given-names": "T", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Morwood", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Jungers", 
-                        "given-names": "WL", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The primitive wrist of <italic>Homo floresiensis</italic> and its implicatiosn for hominin evolution", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib64", 
+                "date": "2007", 
+                "articleTitle": "The primitive wrist of <italic>Homo floresiensis</italic> and its implicatiosn for hominin evolution", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "317", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1147143", 
-                "fpage": "1743", 
-                "year": "2007", 
-                "position": 63, 
-                "ref": "TocheriMWOrrCMLarsonSGSutiknaTJatmikoSaptomoEWDueRADjubiantonoTMorwoodMJJungersWL2007The primitive wrist of Homo floresiensis and its implicatiosn for hominin evolutionScience3171743174510.1126/science.1147143", 
-                "id": "bib64"
+                "pages": {
+                    "first": "1743", 
+                    "last": "1745", 
+                    "range": "1743\u20131745"
+                }, 
+                "doi": "10.1126/science.1147143"
             }, 
             {
-                "article_title": "A 3D quantitative comparison of trapezium and trapezoid relative articular and nonarticular surface areas in modern humans and great apes", 
-                "lpage": "586", 
-                "doi": "10.1016/j.jhevol.2005.06.005", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Tocheri", 
-                        "given-names": "MW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Razdan", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Williams", 
-                        "given-names": "RC", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Marzke", 
-                        "given-names": "MW", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "A 3D quantitative comparison of trapezium and trapezoid relative articular and nonarticular surface areas in modern humans and great apes", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib65", 
+                "date": "2005", 
+                "articleTitle": "A 3D quantitative comparison of trapezium and trapezoid relative articular and nonarticular surface areas in modern humans and great apes", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "49", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1016/j.jhevol.2005.06.005", 
-                "fpage": "570", 
-                "year": "2005", 
-                "position": 64, 
-                "ref": "TocheriMWRazdanAWilliamsRCMarzkeMW2005A 3D quantitative comparison of trapezium and trapezoid relative articular and nonarticular surface areas in modern humans and great apesJournal of Human Evolution4957058610.1016/j.jhevol.2005.06.005", 
-                "id": "bib65"
+                "pages": {
+                    "first": "570", 
+                    "last": "586", 
+                    "range": "570\u2013586"
+                }, 
+                "doi": "10.1016/j.jhevol.2005.06.005"
             }, 
             {
-                "article_title": "A new skull of early Homo from Dmanisi, Georgia", 
-                "lpage": "89", 
-                "doi": "10.1126/science.1072953", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Vekua", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Lordkipanidze", 
-                        "given-names": "D", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Rightmire", 
-                        "given-names": "GP", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Agusti", 
-                        "given-names": "J", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Ferring", 
-                        "given-names": "R", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Maisuradze", 
-                        "given-names": "G", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Mouskhelishvili", 
-                        "given-names": "A", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Nioradze", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "De Leon", 
-                        "given-names": "MP", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tappen", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tvalchrelidze", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Zollikofer", 
-                        "given-names": "C", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "A new skull of early <italic>Homo</italic> from Dmanisi, Georgia", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib66", 
+                "date": "2002", 
+                "articleTitle": "A new skull of early <italic>Homo</italic> from Dmanisi, Georgia", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "297", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1072953", 
-                "fpage": "85", 
-                "year": "2002", 
-                "position": 65, 
-                "ref": "VekuaALordkipanidzeDRightmireGPAgustiJFerringRMaisuradzeGMouskhelishviliANioradzeMDe LeonMPTappenMTvalchrelidzeMZollikoferC2002A new skull of early Homo from Dmanisi, GeorgiaScience297858910.1126/science.1072953", 
-                "id": "bib66"
+                "pages": {
+                    "first": "85", 
+                    "last": "89", 
+                    "range": "85\u201389"
+                }, 
+                "doi": "10.1126/science.1072953"
             }, 
             {
-                "article_title": "New postcranial fossils of Australopithecus afarensis from hadar, Ethiopia (1990\u20132007)", 
-                "lpage": "51", 
-                "doi": "10.1016/j.jhevol.2011.11.012", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Ward", 
-                        "given-names": "CV", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kimbel", 
-                        "given-names": "WH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Harmon", 
-                        "given-names": "EH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Johanson", 
-                        "given-names": "DC", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "New postcranial fossils of <italic>Australopithecus afarensis</italic> from hadar, Ethiopia (1990\u20132007)", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib67", 
+                "date": "2012", 
+                "articleTitle": "New postcranial fossils of <italic>Australopithecus afarensis</italic> from hadar, Ethiopia (1990\u20132007)", 
+                "journal": {
+                    "name": [
+                        "Journal of Human Evolution"
+                    ]
+                }, 
                 "volume": "63", 
-                "source": "Journal of Human Evolution", 
-                "reference_id": "10.1016/j.jhevol.2011.11.012", 
-                "fpage": "1", 
-                "year": "2012", 
-                "position": 66, 
-                "ref": "WardCVKimbelWHHarmonEHJohansonDC2012New postcranial fossils of Australopithecus afarensis from hadar, Ethiopia (1990\u20132007)Journal of Human Evolution6315110.1016/j.jhevol.2011.11.012", 
-                "id": "bib67"
+                "pages": {
+                    "first": "1", 
+                    "last": "51", 
+                    "range": "1\u201351"
+                }, 
+                "doi": "10.1016/j.jhevol.2011.11.012"
             }, 
             {
-                "article_title": "Early Pleistocene third metacarpal from Kenya and the evolution of modern human-like hand morphology", 
-                "lpage": "124", 
-                "doi": "10.1073/pnas.1316014110", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Ward", 
-                        "given-names": "CV", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Tocheri", 
-                        "given-names": "MW", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Plavcan", 
-                        "given-names": "JM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Brown", 
-                        "given-names": "FH", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kyalo Manthi", 
-                        "given-names": "F", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "Early Pleistocene third metacarpal from Kenya and the evolution of modern human-like hand morphology", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib68", 
+                "date": "2013", 
+                "articleTitle": "Early Pleistocene third metacarpal from Kenya and the evolution of modern human-like hand morphology", 
+                "journal": {
+                    "name": [
+                        "Proceedings of the National Academy of Sciences of USA"
+                    ]
+                }, 
                 "volume": "111", 
-                "source": "Proceedings of the National Academy of Sciences of USA", 
-                "reference_id": "10.1073/pnas.1316014110", 
-                "fpage": "121", 
-                "year": "2013", 
-                "position": 67, 
-                "ref": "WardCVTocheriMWPlavcanJMBrownFHKyalo ManthiF2013Early Pleistocene third metacarpal from Kenya and the evolution of modern human-like hand morphologyProceedings of the National Academy of Sciences of USA11112112410.1073/pnas.1316014110", 
-                "id": "bib68"
+                "pages": {
+                    "first": "121", 
+                    "last": "124", 
+                    "range": "121\u2013124"
+                }, 
+                "doi": "10.1073/pnas.1316014110"
             }, 
             {
-                "article_title": "The skull of Sinanthropus", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Weidenreich", 
-                        "given-names": "F", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The skull of <italic>Sinanthropus</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib69", 
+                "date": "1943", 
+                "articleTitle": "The skull of <italic>Sinanthropus</italic>", 
+                "journal": {
+                    "name": [
+                        "Palaeontologia Sinica"
+                    ]
+                }, 
                 "volume": "10", 
-                "source": "Palaeontologia Sinica", 
-                "fpage": "1", 
-                "year": "1943", 
-                "position": 68, 
-                "ref": "WeidenreichF1943The skull of SinanthropusPalaeontologia Sinica101", 
-                "id": "bib69"
+                "pages": "1"
             }, 
             {
-                "publisher_loc": "Oxford", 
-                "article_doi": "10.7554/eLife.09560", 
-                "publisher_name": "Clarendon", 
-                "year": "1991", 
-                "publication-type": "book", 
-                "source": "Koobi Fora research project IV: hominid cranial remains from Koobi Fora", 
-                "authors": [
-                    {
-                        "surname": "Wood", 
-                        "given-names": "BA", 
-                        "group-type": "author"
+                "type": "book", 
+                "id": "bib70", 
+                "date": "1991", 
+                "bookTitle": "Koobi Fora research project IV: hominid cranial remains from Koobi Fora", 
+                "publisher": {
+                    "name": [
+                        "Clarendon"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Oxford"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Oxford"
+                            ]
+                        }
                     }
-                ], 
-                "position": 69, 
-                "ref": "WoodBA1991Koobi Fora research project IV: hominid cranial remains from Koobi ForaOxfordClarendon", 
-                "id": "bib70"
+                }
             }, 
             {
-                "article_title": "The human genus", 
-                "lpage": "71", 
-                "doi": "10.1126/science.284.5411.65", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Wood", 
-                        "given-names": "BA", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Collard", 
-                        "given-names": "M", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The human genus", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib71", 
+                "date": "1999", 
+                "articleTitle": "The human genus", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "284", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.284.5411.65", 
-                "fpage": "65", 
-                "year": "1999", 
-                "position": 70, 
-                "ref": "WoodBACollardM1999The human genusScience284657110.1126/science.284.5411.65", 
-                "id": "bib71"
+                "pages": {
+                    "first": "65", 
+                    "last": "71", 
+                    "range": "65\u201371"
+                }, 
+                "doi": "10.1126/science.284.5411.65"
             }, 
             {
-                "article_title": "The foot and ankle of Australopithecus sediba", 
-                "lpage": "1420", 
-                "doi": "10.1126/science.1202703", 
-                "article_doi": "10.7554/eLife.09560", 
-                "authors": [
-                    {
-                        "surname": "Zipfel", 
-                        "given-names": "B", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "DeSilva", 
-                        "given-names": "JM", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Kidd", 
-                        "given-names": "RS", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Carlson", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Churchill", 
-                        "given-names": "SE", 
-                        "group-type": "author"
-                    }, 
-                    {
-                        "surname": "Berger", 
-                        "given-names": "LR", 
-                        "group-type": "author"
-                    }
-                ], 
-                "full_article_title": "The foot and ankle of <italic>Australopithecus sediba</italic>", 
-                "publication-type": "journal", 
+                "type": "journal", 
+                "id": "bib72", 
+                "date": "2011", 
+                "articleTitle": "The foot and ankle of <italic>Australopithecus sediba</italic>", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "333", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1202703", 
-                "fpage": "1417", 
-                "year": "2011", 
-                "position": 71, 
-                "ref": "ZipfelBDeSilvaJMKiddRSCarlsonKJChurchillSEBergerLR2011The foot and ankle of Australopithecus sedibaScience3331417142010.1126/science.1202703", 
-                "id": "bib72"
+                "pages": {
+                    "first": "1417", 
+                    "last": "1420", 
+                    "range": "1417\u20131420"
+                }, 
+                "doi": "10.1126/science.1202703"
             }
         ], 
         "decisionLetter": {

--- a/src/tests/test_validate.py
+++ b/src/tests/test_validate.py
@@ -80,6 +80,50 @@ class TestArticleValidate(BaseCase):
         expected = [{'type': 'box', 'title': 'Placeholder box title because we must have one'}]
         self.assertEqual(validate.fix_box_title_if_missing(body_json), expected)
 
+    def test_references_rewrite_missing_date(self):
+        references_json = [{}]
+        expected = [{'date': '1000'}]
+        self.assertEqual(validate.references_rewrite(references_json), expected)
+
+    def test_references_rewrite_journal_missing_pages(self):
+        references_json = [{'type': 'journal',
+                            'articleTitle': '',
+                            'journal': '',
+                            'date': '2016',
+                            'authors': ''}]
+        expected = [{'type': 'journal',
+                     'articleTitle': '',
+                     'journal': '',
+                     'date': '2016',
+                     'authors': '',
+                     'pages': 'placeholderforrefwithnopages'}]
+        self.assertEqual(validate.references_rewrite(references_json), expected)
+
+    def test_references_rewrite_book_missing_data(self):
+        references_json = [{'type': 'book',
+                            'date': '2016',
+                            'authors': ''}]
+        expected = [{'type': 'book',
+                     'date': '2016',
+                     'authors': '',
+                     'publisher': {'name': ['This is a placeholder book publisher name for ref that does not have one']},
+                     'bookTitle': 'Placeholder book title for book or book-chapter missing one'
+                        }]
+        self.assertEqual(validate.references_rewrite(references_json), expected)
+
+    def test_references_rewrite_thesis_missing_author(self):
+        references_json = [{'type': 'thesis', 'date': '2016'}]
+        expected = [{'type': 'thesis',
+                     'date': '2016',
+                     'author': {
+                        "type": "person",
+                        "name": {
+                            "preferred": "Person One",
+                            "index": "One, Person"
+                        }
+                    }}]
+        self.assertEqual(validate.references_rewrite(references_json), expected)
+
     def test_is_poa_not_poa(self):
         # For test coverage
         self.assertFalse(validate.is_poa({}))

--- a/src/validate.py
+++ b/src/validate.py
@@ -225,7 +225,7 @@ def references_rewrite(references):
             ref["date"] = re.sub("[^0-9]", "", ref["date"])
         elif "date" not in ref:
             ref["date"] = "1000"
-        if ref["type"] in ["other", "journal"]:
+        if ref.get("type") in ["other", "journal"]:
             # The schema cannot support type other, turn this into a basic journal reference
             #  to pass validation, also fix missing values on journal type references
             ref["type"] = "journal"
@@ -239,9 +239,9 @@ def references_rewrite(references):
                 if "source" in ref:
                     ref["journal"]["name"].append(ref["source"])
                     del ref["source"]
-        if ref["type"] in ["journal", "book-chapter", "software"] and not "pages" in ref:
+        if ref.get("type") in ["journal", "book-chapter", "software"] and not "pages" in ref:
             ref["pages"] = "placeholderforrefwithnopages"
-        if ref["type"] in ["book", "book-chapter"]:
+        if ref.get("type") in ["book", "book-chapter"]:
             if not "publisher" in ref:
                 ref["publisher"] = {}
                 ref["publisher"]["name"] = []
@@ -249,13 +249,13 @@ def references_rewrite(references):
                     "This is a placeholder book publisher name for ref that does not have one")
             if not "bookTitle" in ref:
                 ref["bookTitle"] = "Placeholder book title for book or book-chapter missing one"
-        if (ref["type"] in ["book", "book-chapter", "conference-proceeding", "data",
+        if (ref.get("type") in ["book", "book-chapter", "conference-proceeding", "data",
                             "journal", "software", "web"]
                 and "authors" not in ref):
             ref["authors"] = placeholder_reference_authors
-        elif ref["type"] in ["thesis"]:
+        elif ref.get("type") in ["thesis"]:
             ref["author"] = placeholder_reference_authors[0]
-        if ref["type"] in ["book-chapter"] and not "editors" in ref:
+        if ref.get("type") in ["book-chapter"] and not "editors" in ref:
             ref["editors"] = placeholder_reference_authors
 
     return references

--- a/src/validate.py
+++ b/src/validate.py
@@ -17,32 +17,6 @@ _handler2.setLevel(logging.INFO)
 _handler2.setFormatter(logging.Formatter('%(levelname)s - %(message)s'))
 LOG.addHandler(_handler2)
 
-placeholder_authors = [{
-    "type": "person",
-    "name": {
-        "preferred": "Lee R Berger",
-        "index": "Berger, Lee R"
-    },
-    "affiliations": [{
-        "name": [
-            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences",
-            "University of the Witwatersrand"
-        ],
-        "address": {
-            "formatted": [
-                "Johannesburg",
-                "South Africa"
-            ],
-            "components": {
-                "locality": [
-                    "Johannesburg"
-                ],
-                "country": "South Africa"
-            }
-        }
-    }]
-}]
-
 placeholder_reference_authors = [
     {
         "type": "person",
@@ -270,7 +244,6 @@ def is_poa(contents):
 def add_placeholders_for_validation(contents):
     art = contents['article']
 
-    #art['authors'] = placeholder_authors
     art['statusDate'] = '2016-01-01T00:00:00Z'
 
     # the versionDate is discarded when the article is not v1


### PR DESCRIPTION
Basic functionality to use the parser references_json() function. It also has validation rewrites and placeholders to get the most valid XML possible at this time.

No need to merge, but it can be if you like it @lsh-0.

Still to do with references is
- adding authors and all other people
- converting references to "unknown" type if they will not pass validation. That should make it so placeholders are no longer required, so this is an interim step to that goal