### PR TITLE
related articles now returns an empty array

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -289,7 +289,8 @@ VOR_SNIPPET.update(OrderedDict([
 VOR = copy.deepcopy(VOR_SNIPPET)
 VOR.update(OrderedDict([
     ('keywords', [jats('keywords')]),
-    ('relatedArticles', [jats('related_article'), related_article_to_related_articles]),
+    #('relatedArticles', [jats('related_article'), related_article_to_related_articles]),
+    ('relatedArticles', [[]]),
     ('digest', [jats('digest_json')]),
     ('body', [jats('body')]), # ha! so easy ...
     ('references', [jats('references_json')]),

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -28,6 +28,7 @@ class ArticleScrape(BaseCase):
         results = main.render_single(self.doc, version=1)
         self.assertTrue('article' in results)
         self.assertTrue('journal' in results)
+        self.assertEqual(results['article']['relatedArticles'], [])
         # NOTE! leave article validation to json schema
         # expected_article = json.load(
         # self.assertEqual(results.


### PR DESCRIPTION
related articles are not part of the articles deliverable, returning an empty array until we can tackle is properly