### PR TITLE
No longer need to convert abstract to impact statement. Fix for tests…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,3 @@
-from os.path import join
 import os, sys, json, copy, re
 import threading
 from et3.render import render, EXCLUDE_ME
@@ -138,7 +137,7 @@ def pdf_uri(triple):
         return EXCLUDE_ME
     padded_msid = str(int(msid)).zfill(5)
     filename = "elife-%s-v%s.pdf" % (padded_msid, version) # ll: elife-09560-v1.pdf
-    return cdnlink(join('articles', padded_msid, filename))
+    return cdnlink('/'.join(['articles', padded_msid, filename]))
 
 #
 #
@@ -176,16 +175,6 @@ def to_volume(volume):
         # No volume on unpublished PoA articles, calculate based on current year
         volume = THIS_YEAR - 2011
     return int(volume)
-
-def abstract_to_impact_statement(article_or_snippet):
-    # If abstract has no DOI, turn it into an impact statement
-    if "abstract" in article_or_snippet and "impactStatement" not in article_or_snippet:
-        if "doi" not in article_or_snippet["abstract"]:
-            # Take the first paragraph text
-            abstract_text = article_or_snippet["abstract"]["content"][0]["text"]
-            article_or_snippet["impactStatement"] = abstract_text
-            del article_or_snippet["abstract"]
-    return article_or_snippet
 
 def clean_if_none(article_or_snippet):
     remove_if_none = ["pdf", "relatedArticles", "digest", "abstract", "titlePrefix",
@@ -229,9 +218,6 @@ def clean(article_data):
 
     article_json["article"] = clean_copyright(article_json["article"])
     article_json["snippet"] = clean_copyright(article_json["snippet"])
-
-    article_json["article"] = abstract_to_impact_statement(article_json["article"])
-    article_json["snippet"] = abstract_to_impact_statement(article_json["snippet"])
 
     return article_json
 

--- a/src/tests/fixtures/elife-09560-v1.xml.json
+++ b/src/tests/fixtures/elife-09560-v1.xml.json
@@ -16,7 +16,7 @@
         "versionDate": "2015-09-10T00:00:00", 
         "volume": 4, 
         "elocationId": "e09560", 
-        "pdf": "elife-09560-v1.pdf", 
+        "pdf": "https://cdn.elifesciences.org/articles/09560/elife-09560-v1.pdf", 
         "subjects": [
             {
                 "id": "genomics-evolutionary-biology", 
@@ -2319,7 +2319,7 @@
         "versionDate": "2015-09-10T00:00:00", 
         "volume": 4, 
         "elocationId": "e09560", 
-        "pdf": "elife-09560-v1.pdf", 
+        "pdf": "https://cdn.elifesciences.org/articles/09560/elife-09560-v1.pdf", 
         "subjects": [
             {
                 "id": "genomics-evolutionary-biology", 

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -78,12 +78,6 @@ class ArticleScrape(BaseCase):
         expected = None
         self.assertEqual(main.related_article_to_related_articles(related_article_list), expected)
 
-    def test_abstract_to_impact_statement(self):
-        snippet = {'abstract': {'content': [
-            {'type': 'paragraph', 'text': 'abstract with no DOI'}]}}
-        expected = {'impactStatement': 'abstract with no DOI'}
-        self.assertEqual(main.abstract_to_impact_statement(snippet), expected)
-
     def test_clean_if_none(self):
         snippet = {'abstract': None}
         expected = {}


### PR DESCRIPTION
… to pass, uses string join and not os.join when concatenating the CDN URL.