### PR TITLE
No more author rewriting with phone number format moved to elifetools…

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,4 +7,5 @@ omit =
 [report]
 show_missing = false
 precision = 0
-exclude_lines = true
+exclude_lines =
+    if __name__ == .__main__.:

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-import os, sys, json, copy, re
+import os, sys, json, copy
 import threading
 from et3.render import render, EXCLUDE_ME
 from elifetools import parseJATS
@@ -227,15 +227,6 @@ def discard_if_not_v1(v):
         return v
     return EXCLUDE_ME
 
-def authors_rewrite(authors):
-    # Clean up phone number format
-    for author in authors:
-        if "phoneNumbers" in author:
-            for i, phone in enumerate(author["phoneNumbers"]):
-                # Only one phone number so far, simple replace to validate
-                author["phoneNumbers"][i] = re.sub(r'[\(\) -]', '', phone)
-    return authors
-
 #
 #
 #
@@ -275,7 +266,7 @@ POA.update(OrderedDict([
         ('holder', [jats('copyright_holder')]),
         ('statement', [jats('license')]),
     ])),
-    ('authors', [jats('authors_json'), authors_rewrite])
+    ('authors', [jats('authors_json')])
 ]))
 
 # a VOR snippets contains the contents of a POA

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -93,11 +93,6 @@ class ArticleScrape(BaseCase):
         expected = {'copyright': {}}
         self.assertEqual(main.clean_copyright(snippet), expected)
 
-    def test_authors_rewrite(self):
-        authors = [{'phoneNumbers': ['(+1) 800-555-5555']}]
-        expected = [{'phoneNumbers': ['+18005555555']}]
-        self.assertEqual(main.authors_rewrite(authors), expected)
-
     def test_display_channel_to_article_type_fails(self):
         display_channel = ['']
         expected = None


### PR DESCRIPTION
… parser. Also do not count __main__ functions in coverage report to stay above 80% coverage.