### PR TITLE
Example 06959 has a case sensitivity difference, adding "Registered …

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -77,6 +77,7 @@ DISPLAY_CHANNEL_TYPES = {
     "Feature article": "feature",
     "Insight": "insight",
     "Registered Report": "registered-report",
+    "Registered report": "registered-report",
     "Research Advance": "research-advance",
     "Research Article": "research-article",
     "Research article": "research-article",

--- a/src/tests/test_adaptor.py
+++ b/src/tests/test_adaptor.py
@@ -108,6 +108,7 @@ class Adapt(BaseCase):
     def test_patched_data(self):
         "we can optionally send lax the patched version of the article-json"
         expected = {'-patched': True}
+
         def call_lax(*args, **kwargs):
             art = json.loads(kwargs['article_json'])['article']
             for key, val in expected.items():


### PR DESCRIPTION
…report" to the list of match strings for display channel.