### PR TITLE
Script for updating elifetools to the latest version from its develop branch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,9 @@ fi
 
 source venv/bin/activate
 
-pip uninstall -y elifetools
+if pip list | grep elifetools; then
+    pip uninstall -y elifetools
+fi
 pip install -r requirements.txt
 
 . download-api-raml.sh

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ fi
 
 source venv/bin/activate
 
+pip uninstall -y elifetools
 pip install -r requirements.txt
 
 . download-api-raml.sh

--- a/update-elife-tools.sh
+++ b/update-elife-tools.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+rm -rf /tmp/elife-tools-shallow-clone
+git clone --depth 1 https://github.com/elifesciences/elife-tools.git /tmp/elife-tools-shallow-clone
+cd /tmp/elife-tools-shallow-clone
+# this uses the develop branch, which is the default being cloned
+elife_tools_sha1=$(git rev-parse HEAD)
+cd -
+sed -i -e "s;.*/elife-tools.git.*;git+https://github.com/elifesciences/elife-tools.git@${elife_tools_sha1}#egg=elifetools;g" requirements.txt
+source venv/bin/activate
+pip uninstall -y elifetools
+pip install -r requirements.txt
+


### PR DESCRIPTION
Only execute when this is needed, normally elifetools will be pinned to the commit inside `requirements.txt`

Normally `pip freeze` should do this job, but it doesn't work with commits, only with releases.