### PR TITLE
Loading all articles from their web pages

### DIFF
--- a/load_all_urls.sh
+++ b/load_all_urls.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+host=${1-end2end--journal.elifesciences.org}
+
+source venv/bin/activate
+rm -f load_all_urls.log
+python urls.py article-json/ | sort | uniq | xargs -n 1 -I '{}' -P 4 curl -v https://$host'{}' -s -o /dev/null -w "{},%{http_code}\n" | tee -a load_all_urls.log

--- a/urls.py
+++ b/urls.py
@@ -1,0 +1,20 @@
+from glob import glob
+import json
+import sys
+
+def all(folder_json):
+    files = glob("%s/elife-*.json" % folder_json)
+    urls = []
+    for f in files:
+        article = json.load(open(f))
+        urls.append("/content/%d/e%s" % (article['snippet']['volume'], article['snippet']['id']))
+    return urls
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print "Usage: %s folder_json\n" % sys.argv[0]
+        sys.exit(1)
+    for url in all(sys.argv[1]):
+        print url
+
+


### PR DESCRIPTION
This project has the list and content of all articles, so it's very easy
to build URLs for them and load them in parallel to test.

Sample output in `load_all_urls.log`:
```
/content/5/e14203,503
/content/5/e14199,503
/content/5/e14198,503
/content/5/e14211,503
/content/5/e14222,503
/content/5/e14216,503
/content/5/e14228,503
/content/5/e14226,503
/content/5/e14239,503
/content/5/e14243,503
/content/5/e14258,503
/content/5/e14264,503
/content/5/e14274,503
/content/5/e14277,503
/content/5/e14281,503
```