### PR TITLE
other cdn urls

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -125,6 +125,10 @@ def is_poa_to_status(is_poa):
     return "poa" if is_poa else "vor"
 
 def cdnlink(path):
+    use_other_cdn = True
+    if use_other_cdn:
+        _, padded_msid, filename = path.split('/') # 'articles', padded msid, filename
+        return 'https://publishing-cdn.elifesciences.org/%s/%s' % (padded_msid, filename)
     return conf.CDN_PROTOCOL + ':' + conf.CDN_BASE_URL + '/' + path
 
 def pdf_uri(triple):

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -100,7 +100,8 @@ class ArticleScrape(BaseCase):
 
     def test_pdf_uri(self):
         given = ('research-article', 1234, 1)
-        expected = 'https://cdn.elifesciences.org/articles/01234/elife-01234-v1.pdf'
+        #expected = 'https://cdn.elifesciences.org/articles/01234/elife-01234-v1.pdf'
+        expected = 'https://publishing-cdn.elifesciences.org/01234/elife-01234-v1.pdf'
         self.assertEqual(expected, main.pdf_uri(given))
 
     def test_pdf_uri_bad(self):

--- a/src/tests/test_validate.py
+++ b/src/tests/test_validate.py
@@ -98,6 +98,7 @@ class TestArticleValidate(BaseCase):
         expected = {
             'article': {
                 '-patched': True,
+                'id': 01234,
                 'version': 2,
                 'stage': 'published',
                 'versionDate': '2099-01-01T00:00:00Z',

--- a/src/tests/test_validate.py
+++ b/src/tests/test_validate.py
@@ -94,11 +94,11 @@ class TestArticleValidate(BaseCase):
         self.assertEqual(validate.references_rewrite(references_json), expected)
 
     def test_add_placeholders_for_validation(self):
-        article = {'article': {'version': 2}}
+        article = {'article': {'id': 12345, 'version': 2}}
         expected = {
             'article': {
                 '-patched': True,
-                'id': 01234,
+                'id': 12345,
                 'version': 2,
                 'stage': 'published',
                 'versionDate': '2099-01-01T00:00:00Z',

--- a/src/validate.py
+++ b/src/validate.py
@@ -21,11 +21,11 @@ placeholder_reference_authors = [
     }
 ]
 
-def uri_rewrite(body_json):
-    base_uri = "https://example.org/"
+def uri_rewrite(padded_msid, body_json):
+    base_uri = "https://publishing-cdn.elifesciences.org/%s/" % padded_msid
     # Check if it is not a list, in the case of authorResponse
     if "content" in body_json:
-        uri_rewrite(body_json["content"])
+        uri_rewrite(padded_msid, body_json["content"])
     # A list, like in body, continue
     for element in body_json:
         if "uri" in element:
@@ -39,7 +39,7 @@ def uri_rewrite(body_json):
         for content_index in ["content", "supplements", "sourceData"]:
             if content_index in element:
                 try:
-                    uri_rewrite(element[content_index])
+                    uri_rewrite(padded_msid, element[content_index])
                 except TypeError:
                     # not iterable
                     pass
@@ -214,9 +214,11 @@ def add_placeholders_for_validation(contents):
     if 'appendices' in art:
         art['appendices'] = appendices_rewrite(art['appendices'])
 
+    padded_msid = str(art['id']).zfill(5)
+
     for elem in ['body', 'decisionLetter', 'authorResponse', 'appendices']:
         if elem in art:
-            art[elem] = uri_rewrite(art[elem])
+            art[elem] = uri_rewrite(padded_msid, art[elem])
             art[elem] = video_rewrite(art[elem])
             art[elem] = fix_section_id_if_missing(art[elem])
             art[elem] = mathml_rewrite(art[elem])

--- a/src/validate_article_json.py
+++ b/src/validate_article_json.py
@@ -19,7 +19,16 @@ WINDOWS = platform.system().lower() == 'windows'
 
 def job(path):
     strbuffer = StringIO()
-    fn = shutil.copyfile if WINDOWS else os.symlink
+
+    def copyfn(src, dest):
+        if os.path.exists(dest):
+            os.unlink(dest)
+        return shutil.copyfile(src, dest)
+
+    fn = copyfn
+    if WINDOWS:
+        fn = os.symlink
+
     try:
         fname = os.path.basename(path)
         strbuffer.write("%s => " % fname)


### PR DESCRIPTION
* article pdf urls now point to other cdn
* anything else with a 'uri' is now pointing to the other cdn

figure urls never made it into main.py, so that must be remedied, but we're feeding off of the patched ajson right now so there is time.