### PR TITLE
Attempt to make the CDN URL work in end2end

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -306,6 +306,9 @@ def bootstrap():
 
     args = parser.parse_args()
 
+    if args.instance_id == 'end2end':
+        conf.set_temporary_cdn_host('end2end-publishing-cdn.elifesciences.org')
+
     adaptors = {
         'fs': partial(read_from_fs, args.target),
         'sqs': read_from_sqs,

--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -306,8 +306,7 @@ def bootstrap():
 
     args = parser.parse_args()
 
-    if args.instance_id == 'end2end':
-        conf.set_temporary_cdn_host('end2end-publishing-cdn.elifesciences.org')
+    main.setvar(env=args.instance_id)
 
     adaptors = {
         'fs': partial(read_from_fs, args.target),

--- a/src/conf.py
+++ b/src/conf.py
@@ -84,3 +84,6 @@ OTHER_CDN_HOST = 'publishing-cdn.elifesciences.org'
 def set_temporary_cdn_host(host):
     global OTHER_CDN_HOST
     OTHER_CDN_HOST = host
+
+def other_cdn_host():
+    return OTHER_CDN_HOST

--- a/src/conf.py
+++ b/src/conf.py
@@ -77,12 +77,13 @@ VOR_SCHEMA = json_load('api-raml/dist/model/article-vor.v1.json')
 REQUEST_SCHEMA = json_load('request-schema.json')
 RESPONSE_SCHEMA = json_load('response-schema.json')
 
-CDN_PROTOCOL = 'https'
-CDN_BASE_URL = '//cdn.elifesciences.org'
+CDN1 = 'cdn.elifesciences.org/articles/%(padded-msid)s/%(fname)s'
+CDN2 = 'publishing-cdn.elifesciences.org/%(padded-msid)s/%(fname)s'
 
-urls_config = {'other_cdn_host': 'publishing-cdn.elifesciences.org'}
-def set_temporary_cdn_host(host):
-    urls_config['other_cdn_host'] = host
+DEFAULT_CDN = CDN1 if False else CDN2
+CDNS_BY_ENV = {
+    'end2end': 'end2end-' + CDN2,
+}
 
-def other_cdn_host():
-    return urls_config['other_cdn_host']
+def cdn(env=None):
+    return 'https://' + CDNS_BY_ENV.get(env, DEFAULT_CDN)

--- a/src/conf.py
+++ b/src/conf.py
@@ -79,3 +79,8 @@ RESPONSE_SCHEMA = json_load('response-schema.json')
 
 CDN_PROTOCOL = 'https'
 CDN_BASE_URL = '//cdn.elifesciences.org'
+
+OTHER_CDN_HOST = 'publishing-cdn.elifesciences.org'
+def set_temporary_cdn_host(host):
+    global OTHER_CDN_HOST
+    OTHER_CDN_HOST = host

--- a/src/conf.py
+++ b/src/conf.py
@@ -80,10 +80,9 @@ RESPONSE_SCHEMA = json_load('response-schema.json')
 CDN_PROTOCOL = 'https'
 CDN_BASE_URL = '//cdn.elifesciences.org'
 
-OTHER_CDN_HOST = 'publishing-cdn.elifesciences.org'
+urls_config = {'other_cdn_host': 'publishing-cdn.elifesciences.org'}
 def set_temporary_cdn_host(host):
-    global OTHER_CDN_HOST
-    OTHER_CDN_HOST = host
+    urls_config['other_cdn_host'] = host
 
 def other_cdn_host():
-    return OTHER_CDN_HOST
+    return urls_config['other_cdn_host']

--- a/src/main.py
+++ b/src/main.py
@@ -125,7 +125,7 @@ def is_poa_to_status(is_poa):
     return "poa" if is_poa else "vor"
 
 def cdnlink(msid, filename):
-    cdn = conf.cdn(getvar('env'))
+    cdn = conf.cdn(getvar('env', None))
     kwargs = {
         'padded-msid': pad_msid(msid),
         'fname': filename

--- a/src/main.py
+++ b/src/main.py
@@ -128,7 +128,7 @@ def cdnlink(path):
     use_other_cdn = True
     if use_other_cdn:
         _, padded_msid, filename = path.split('/') # 'articles', padded msid, filename
-        return 'https://%s/%s/%s' % (conf.OTHER_CDN_HOST, padded_msid, filename)
+        return 'https://%s/%s/%s' % (conf.other_cdn_host(), padded_msid, filename)
     return conf.CDN_PROTOCOL + ':' + conf.CDN_BASE_URL + '/' + path
 
 def pdf_uri(triple):

--- a/src/main.py
+++ b/src/main.py
@@ -128,7 +128,7 @@ def cdnlink(path):
     use_other_cdn = True
     if use_other_cdn:
         _, padded_msid, filename = path.split('/') # 'articles', padded msid, filename
-        return 'https://publishing-cdn.elifesciences.org/%s/%s' % (padded_msid, filename)
+        return 'https://%s/%s/%s' % (conf.OTHER_CDN_HOST, padded_msid, filename)
     return conf.CDN_PROTOCOL + ':' + conf.CDN_BASE_URL + '/' + path
 
 def pdf_uri(triple):

--- a/src/main.py
+++ b/src/main.py
@@ -124,12 +124,16 @@ def related_article_to_related_articles(related_article_list):
 def is_poa_to_status(is_poa):
     return "poa" if is_poa else "vor"
 
-def cdnlink(path):
-    use_other_cdn = True
-    if use_other_cdn:
-        _, padded_msid, filename = path.split('/') # 'articles', padded msid, filename
-        return 'https://%s/%s/%s' % (conf.other_cdn_host(), padded_msid, filename)
-    return conf.CDN_PROTOCOL + ':' + conf.CDN_BASE_URL + '/' + path
+def cdnlink(msid, filename):
+    cdn = conf.cdn(getvar('env'))
+    kwargs = {
+        'padded-msid': pad_msid(msid),
+        'fname': filename
+    }
+    return cdn % kwargs
+
+def pad_msid(msid):
+    return str(int(msid)).zfill(5)
 
 def pdf_uri(triple):
     """predict an article's pdf url.
@@ -139,9 +143,8 @@ def pdf_uri(triple):
     content_type, msid, version = triple
     if content_type in ['Correction']:
         return EXCLUDE_ME
-    padded_msid = str(int(msid)).zfill(5)
-    filename = "elife-%s-v%s.pdf" % (padded_msid, version) # ll: elife-09560-v1.pdf
-    return cdnlink('/'.join(['articles', padded_msid, filename]))
+    filename = "elife-%s-v%s.pdf" % (pad_msid(msid), version) # ll: elife-09560-v1.pdf
+    return cdnlink(msid, filename)
 
 #
 #

--- a/src/validate.py
+++ b/src/validate.py
@@ -22,7 +22,7 @@ placeholder_reference_authors = [
 ]
 
 def uri_rewrite(padded_msid, body_json):
-    base_uri = "https://publishing-cdn.elifesciences.org/%s/" % padded_msid
+    base_uri = "https://%s/%s/" % (conf.OTHER_CDN_HOST, padded_msid)
     # Check if it is not a list, in the case of authorResponse
     if "content" in body_json:
         uri_rewrite(padded_msid, body_json["content"])

--- a/src/validate.py
+++ b/src/validate.py
@@ -22,7 +22,7 @@ placeholder_reference_authors = [
 ]
 
 def uri_rewrite(padded_msid, body_json):
-    base_uri = "https://%s/%s/" % (conf.OTHER_CDN_HOST, padded_msid)
+    base_uri = "https://%s/%s/" % (conf.other_cdn_host(), padded_msid)
     # Check if it is not a list, in the case of authorResponse
     if "content" in body_json:
         uri_rewrite(padded_msid, body_json["content"])

--- a/src/validate.py
+++ b/src/validate.py
@@ -1,7 +1,7 @@
 import os, sys, json, re
 import conf
 import jsonschema
-
+import main as scraper
 import logging
 LOG = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ placeholder_reference_authors = [
 
 def uri_rewrite(padded_msid, body_json):
     #base_uri = "https://%s/%s/" % (conf.other_cdn_host(), padded_msid)
-    base_uri = conf.cdn()
+    base_uri = conf.cdn(scraper.getvar('env', None))
     # Check if it is not a list, in the case of authorResponse
     if "content" in body_json:
         uri_rewrite(padded_msid, body_json["content"])

--- a/src/validate.py
+++ b/src/validate.py
@@ -22,7 +22,8 @@ placeholder_reference_authors = [
 ]
 
 def uri_rewrite(padded_msid, body_json):
-    base_uri = "https://%s/%s/" % (conf.other_cdn_host(), padded_msid)
+    #base_uri = "https://%s/%s/" % (conf.other_cdn_host(), padded_msid)
+    base_uri = conf.cdn()
     # Check if it is not a list, in the case of authorResponse
     if "content" in body_json:
         uri_rewrite(padded_msid, body_json["content"])
@@ -33,7 +34,8 @@ def uri_rewrite(padded_msid, body_json):
         if (("type" in element and element["type"] == "image") or
                 ("mediaType" in element)):
             if "uri" in element:
-                element["uri"] = base_uri + element["uri"]
+                #element["uri"] = base_uri + element["uri"]
+                element["uri"] = base_uri % {'fname': element["uri"], 'padded-msid': padded_msid}
                 # Add or edit file extension
                 # TODO!!
         for content_index in ["content", "supplements", "sourceData"]:


### PR DESCRIPTION
Sooner or later bot-lax-adaptor will need a configuration file, but while we have an hack with the 'other CDN' we can customize it per-environment to be able to test the correct linking to images in `end2end`

The CDN has not been created yet, but I'd like to get confirmation of the name first. As always, \`end2end\` and \`prod\` environments must be identical.