### PR TITLE
Updating elife-article-json automatically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,14 @@ elifeLibrary {
         archive 'validation.log'
         sh './validate-statistics.sh validation.log'
     }
-    
+
     elifeMainlineOnly {    
+        stage 'Push updated article JSON' {
+            sh 'git clone git@github.com:elifesciences/elife-article-json /tmp/elife-article-json'
+            sh './copy-json.sh /tmp/elife-article-json/articles'
+            sh 'cd /tmp/elife-article-json; git push'
+        }
+
         stage 'Master', {
             elifeGitMoveToBranch elifeGitRevision(), 'master'
         }

--- a/copy-json.sh
+++ b/copy-json.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# copies the article-json found in the `./article-json/valid` directory 
+# to a working copy of the elife-article-json repository.
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ${0} /tmp/elife-article-json"
+    exit 1
+fi
+
+target_repository=$1
+cp ./article-json/valid/*.json $target_repository/articles/
+cd $target_repository
+git diff --exit-code > /dev/null || {
+    git add articles/
+    modified_articles=$(git diff --cached --name-status | wc -l)
+    git commit -m "Added or modified $modified_articles articles"
+}
+cd -


### PR DESCRIPTION
Every time we merge a new correct version of bot-lax-adaptor into
`master` we get for free the opportunity to update the new elife-article-json
with the valid articles.

We don't want to do this on pull requests, but only on the mainline after it has passed all tests and the version is going to production (since production uses the `master` branch).

This procedure uses a temporary copy of elife-article-json for portability, but we may want to optimize it later.

And of course, by keeping updated this repository we can use it for backfills cutting away a lot of the time needed as generation and validation have already been performed. By looking only at the last modified files we may be able to also backfill only a subset of the corpus instead of everything.