### PR TITLE
Guinea pigs before full article corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv/*
 article-xml/
 article-json/
 article-json*/
+guinea-pigs/
 api-raml/
 htmlcov/
 elife-tools/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,12 @@ elifeLibrary {
         sh 'git diff --exit-code'
     }
 
-    stage 'Corpus generation', {
+    stage 'Guinea pigs', {
         sh './download-elife-xml.sh'
+        sh './guinea-pigs.sh'
+    }
+
+    stage 'Corpus generation', {
         sh 'rm -f generation.log'
         sh './generate-article-json.sh'
         archive 'generation.log'

--- a/guinea-pigs.sh
+++ b/guinea-pigs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# generates a validate a small subset of articles that should always pass
+
+set -e
+
+guinea_pigs="
+elife-00230-v1.xml
+elife-00625-v1.xml
+elife-00790-v1.xml
+elife-01222-v1.xml
+elife-01239-v1.xml
+elife-03318-v1.xml
+elife-04177-v2.xml
+elife-04637-v1.xml
+elife-04970-v2.xml
+elife-06213-v3.xml
+elife-08245-v1.xml
+elife-10635-v2.xml
+elife-15600-v1.xml
+elife-15853-v1.xml
+elife-15893-v1.xml
+"
+
+mkdir -p guinea-pigs
+rm -f guinea-pigs/* guinea-pigs.log
+for article in $guinea_pigs; do
+    echo "Guinea pig ${article}"
+    ./scrape-article.sh article-xml/articles/$article >> guinea-pigs/$article.json
+    ./validate-json.sh guinea-pigs/$article.json >> guinea-pigs.log
+done

--- a/scrape-article.sh
+++ b/scrape-article.sh
@@ -2,9 +2,12 @@
 # generates article-json from a random article in the elife-article-xml repo
 set -e # everything must pass
 
-. install.sh > /dev/null
+if [ ! -d venv ]; then
+    . install.sh > /dev/null
+fi
+source venv/bin/activate
 
-if [ -d $PWD ]; then
+if [ ! -d article-xml ]; then
     . download-elife-xml.sh &> /dev/null
 fi
 

--- a/validate-json.sh
+++ b/validate-json.sh
@@ -4,13 +4,17 @@
 
 set -e # everything must pass
 
+if [ ! -d venv ]; then
+    . install.sh > /dev/null
+fi
+source venv/bin/activate
+
 filename=$1
 
 # zero out the validation log
 # python writes to this file
 echo > validate.log
 
-. install.sh
 
 # trap ctrl-c and call ctrl_c()
 trap ctrl_c INT


### PR DESCRIPTION
Run a well-selected subset of the corpus first through generation and validation, and fail immediately the build if any of them has a problem.

Incidentally, avoid continuously reinstalling things in the scripts for performance; but do so lazily on new working copies that don't have venv/ and similar folders