### PR TITLE
Lowering threshold to 79 invalid articles

### DIFF
--- a/validate-statistics.sh
+++ b/validate-statistics.sh
@@ -3,7 +3,7 @@
 set -e
 
 log=$1
-maximum_invalid=88
+maximum_invalid=79
 article_pattern='\- elife-[0-9]\+-v[0-9]\+\.xml\.json =>'
 
 validated_green=$(grep "$article_pattern" "$log" | grep success | wc -l)


### PR DESCRIPTION
`15:13:22 Output invalid: 79 JSON articles`, no reason to keep it higher