### PR TITLE
Explicitly specifying to run on the elife-libraries--powerful node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-elifeLibrary {
+elifeLibrary({
     stage 'Checkout', {
         checkout scm
     }
@@ -39,4 +39,4 @@ elifeLibrary {
             elifeGitMoveToBranch elifeGitRevision(), 'master'
         }
     }
-}
+}, 'elife-libraries--powerful')


### PR DESCRIPTION
In the future, elifeLibrary will run by default on a smaller node