### PR TITLE
Supporting multiple processes

### DIFF
--- a/.bot-lax-listener.sh
+++ b/.bot-lax-listener.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+source venv/bin/activate
+
+# the 'ci' in 'lax--ci'
+instance_id=$1
+
+exec python src/adaptor.py --type sqs --instance "$instance_id"

--- a/bot-lax-listener.sh
+++ b/bot-lax-listener.sh
@@ -3,8 +3,4 @@
 set -e
 
 . install.sh
-
-# the 'ci' in 'lax--ci'
-instance_id=$1
-
-exec python src/adaptor.py --type sqs --instance "$instance_id"
+./.bot-lax-listener.sh


### PR DESCRIPTION
If we were to run 2 instances of bot-lax-listener.sh:
- they will compete for messages from the incoming SQS queue, which will get to one or the other
- they will execute Lax commands through the shell to import the article-json produced (afaik)
- they will queue messages for the bot in the outgoing SQS queue, which
will be processed by the bot in any order

There are no other point of contentions that I know, but we have to
avoid reinstalling the virtualenv every time the process is started or
multiple copies are going to clash on that.