### PR TITLE
Fix UTF-8 problems when downloading an XML file

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -115,6 +115,7 @@ def http_download(location):
     resp = requests.get(location, auth=cred)
     if resp.status_code != 200:
         raise RuntimeError("failed to download xml from location %r, got response code: %s" % (location, resp.status_code))
+    resp.encoding = 'utf-8'
     return resp.text
 
 def download(location):

--- a/src/tests/test_adaptor.py
+++ b/src/tests/test_adaptor.py
@@ -125,4 +125,3 @@ class Adapt(BaseCase):
         # this is a crappy quick regex to extract the XML tags we need
         titles_of_appendices = re.findall('<title>Appendix[^<]*</title>', xml_text)
         self.assertIn(u'<title>Appendix\xa01</title>', titles_of_appendices)
-        

--- a/src/tests/test_adaptor.py
+++ b/src/tests/test_adaptor.py
@@ -1,4 +1,4 @@
-import os, json
+import os, json, re
 from os.path import join
 from .base import BaseCase
 import adaptor as adapt, fs_adaptor, conf
@@ -115,3 +115,14 @@ class Adapt(BaseCase):
             return {'status': conf.INGESTED, 'message': 'mock'}
         with patch('adaptor.call_lax', call_lax):
             adaptor.do(*adaptor.read_from_fs(join(self.ingest_dir, 'v3')))
+
+    def test_http_download(self):
+        # this needs to be an UTF-8 XML document
+        # without a proper 'Content-Type: application/xml; encoding=utf-8'
+        # header being attached to the response
+        test_url = 'http://publishing-cdn.elifesciences.org/18722/elife-18722-v2.xml'
+        xml_text = adaptor.http_download(test_url)
+        # this is a crappy quick regex to extract the XML tags we need
+        titles_of_appendices = re.findall('<title>Appendix[^<]*</title>', xml_text)
+        self.assertIn(u'<title>Appendix\xa01</title>', titles_of_appendices)
+        


### PR DESCRIPTION
Long story short, the XML in the S3 bucket are stored and served with `application/xml` as `Content-Type`, that doesn't specify an encoding. So `requests` stick tries some heuristics to guess the encoding but ultimately has undefined behavior.

Here we force these response to always be treated like they contain
UTF-8.