### PR TITLE
Avoid dependency on Bitbucket when ingesting or publishing articles

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -70,6 +70,7 @@ def find_lax():
 def call_lax(action, id, version, token, article_json=None, force=False, dry_run=False):
     cmd = [
         find_lax(), # /srv/lax/manage.sh
+        "--skip-install",
         "ingest",
         "--" + action, # ll: --ingest+publish
         "--id", str(id),


### PR DESCRIPTION
Using the new `--skip-install` flag should remove the reinstall of all
Python dependencies on every article publishing and hence this failure
mode, plus saving a few seconds in every test.