### PR TITLE
Allowing 1 non-generatable article

### DIFF
--- a/generate-statistics.sh
+++ b/generate-statistics.sh
@@ -3,6 +3,7 @@
 set -e
 
 log=$1
+maximum_not_generatable=1
 article_pattern='\- elife-[0-9]\+-v[0-9]\+\.xml ->'
 
 generated_green=$(grep "$article_pattern" "$log" | grep success | wc -l)
@@ -19,8 +20,8 @@ if [ ! "$generated_total" -eq "$input" ]; then
     exit 2
 fi
 
-if [ "$generated_red" -gt 0 ]; then
+if [ "$generated_red" -gt "$maximum_not_generatable" ]; then
     echo "No articles should be failing generation"
     grep "${article_pattern}" "$log" | grep -v success
-    exit $generated_red
+    exit "${generated_red}"
 fi


### PR DESCRIPTION
07398-v2 has some problems on mismatches with the Glencoe side:
```
12:31:21 INFO - 2017-03-21 12:20:17,698 - elife-07398-v2.xml ->
elife-07398-v2.xml.json => failed (glencoe doesn't know u'media15', only
u'respmedia1, respmedia2, media10, media11, media12, media13, media14,
media2, media3, media1, media6, media7, media4, media5, media8, media9')
```
and we don't want to wait for it.

Also, I checked and `generatable` is a real word.