### PR TITLE
Script for testing with the IIIF version of api-raml

### DIFF
--- a/download-api-raml.sh
+++ b/download-api-raml.sh
@@ -4,6 +4,9 @@
 # is used to validate what the scraper generates.
 # see `src/validate.py`
 
+pinned_api_raml_commit=$(cat api-raml.sha1)
+api_raml_commit="${1:-$pinned_api_raml_commit}"
+
 set -e # everything must pass
 cd schema
 if [ ! -d api-raml ]; then
@@ -11,11 +14,9 @@ if [ ! -d api-raml ]; then
 fi
 cd ..
 
-if [ -f api-raml.sha1 ]; then
-    cd schema/api-raml
-    # existing api-raml shallow clones, containing only 1 commit
-    git reset --hard
-    git fetch origin
-    git checkout "$(cat ../../api-raml.sha1)"
-    cd -
-fi
+cd schema/api-raml
+# existing api-raml shallow clones, containing only 1 commit
+git reset --hard
+git fetch origin
+git checkout "${api_raml_commit}"
+cd -

--- a/guinea-pigs-iiif.sh
+++ b/guinea-pigs-iiif.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# tests the guinea pigs articles with the new iiif schema
+
+cd schema/api-raml
+git fetch origin +refs/pull/*:refs/pull/* # download commits of PRs
+cd -
+./download-api-raml.sh refs/pull/122/head
+cd schema/api-raml
+npm install
+node compile.js
+cd -
+./guinea-pigs.sh
+


### PR DESCRIPTION
Run `./guinea-pigs-iiif.sh` to switch the api-raml and validate the guines pigs articles with it. Now, this leads to a failure, as expected.

After the switch has been made just `./guinea-pigs.sh` can be run to test the effect of code changes.

This script is not being run into the builds, it's a temporary check. Actually, the build will check the code works with the current version of the schema rather than the future one.