### PR TITLE
Generate IIIF links that use the IIIF CDNs

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -120,14 +120,13 @@ CDNS_BY_ENV = {
 CDN = 'https://' + CDNS_BY_ENV.get(ENV, DEFAULT_CDN)
 
 if ENV in ['prod', 'continuumtest', 'end2end']:
-    # this coincides with the IIIF server now, but it will be put behind a CDN soon
     # used for generating public links
-    CDN_IIIF = 'https://' + ENV + '--iiif.elifesciences.org/lax:%(padded-msid)s/%(fname)s'
+    CDN_IIIF = 'https://' + ENV + '-cdn-iiif.elifesciences.org/lax:%(padded-msid)s/%(fname)s'
     # used for direct access to the IIIF server
     IIIF = 'https://' + ENV + '--iiif.elifesciences.org/lax:%(padded-msid)s/%(fname)s'
 else:
     # default to prod as a data source for testing
-    CDN_IIIF = 'https://prod--iiif.elifesciences.org/lax:%(padded-msid)s/%(fname)s'
+    CDN_IIIF = 'https://prod--cdn-iiif.elifesciences.org/lax:%(padded-msid)s/%(fname)s'
     IIIF = 'https://prod--iiif.elifesciences.org/lax:%(padded-msid)s/%(fname)s'
 
 # NOTE: do not move to /tmp

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -269,9 +269,9 @@ class KitchenSink(BaseCase):
                 "source": {
                     "filename": "elife-00666-video1.jpg",
                     "mediaType": "image/jpeg",
-                    "uri": "https://prod--iiif.elifesciences.org/lax:00666/elife-00666-video1.jpg/full/full/0/default.jpg"
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:00666/elife-00666-video1.jpg/full/full/0/default.jpg"
                 },
-                "uri": "https://prod--iiif.elifesciences.org/lax:00666/elife-00666-video1.jpg"
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:00666/elife-00666-video1.jpg"
             },
             "sourceData": [{
                 "doi": "10.7554/eLife.00666.036",


### PR DESCRIPTION
IIIF servers have a CDN now, so we can point there for caching on the
edge the tiles and resizes being generated.

When accessing the info.json files, we directly go to the IIIF server
since it's in the same availability zone and (maybe) data center, and we
cache the result locally.