### PR TITLE
Log error responses

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -114,7 +114,7 @@ def http_download(location):
             cred = S3Auth(*cred)
     resp = requests.get(location, auth=cred)
     if resp.status_code != 200:
-        raise RuntimeError("failed to download xml from location %r, got response code: %s" % (location, resp.status_code))
+        raise RuntimeError("failed to load %r, got response code: %s\n%s" % (location, resp.status_code, resp.content))
     resp.encoding = 'utf-8'
     return resp.text
 
@@ -157,7 +157,7 @@ def mkresponse(status, message, request={}, **kwargs):
         INGESTED: logging.DEBUG,
         PUBLISHED: logging.DEBUG
     }
-    LOG.log(levels[packet["status"]], "%s response", packet['status'], extra=context)
+    LOG.log(levels[packet["status"]], "%s response: %s", packet['status'], context)
 
     # bit ick
     if not packet['message']:

--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -114,7 +114,7 @@ def http_download(location):
             cred = S3Auth(*cred)
     resp = requests.get(location, auth=cred)
     if resp.status_code != 200:
-        raise RuntimeError("failed to load %r, got response code: %s\n%s" % (location, resp.status_code, resp.content))
+        raise RuntimeError("failed to download xml from %r, got response code: %s\n%s" % (location, resp.status_code, resp.content))
     resp.encoding = 'utf-8'
     return resp.text
 

--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -157,7 +157,7 @@ def mkresponse(status, message, request={}, **kwargs):
         INGESTED: logging.DEBUG,
         PUBLISHED: logging.DEBUG
     }
-    LOG.log(levels[packet["status"]], "%s response: %s", packet['status'], context)
+    LOG.log(levels[packet["status"]], "%s response", packet['status'], extra=context)
 
     # bit ick
     if not packet['message']:


### PR DESCRIPTION
The loggers set up on stderr and on adaptor.log ignore the extra parameter, hence error responses are not logged. By putting the responses inside the formatted message they become accessible.

Moreover, the message in http_download does not need to take into account the context of the file being an XML, as this is redundant with the message set in the `except` clause that catches it