### PR TITLE
Accessing S3 through a consistent interface

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -106,7 +106,7 @@ def file_handler(path):
 
 def http_download(location):
     cred = None
-    if location.startswith('https://s3-external-1.amazonaws.com'):
+    if location.startswith('https://s3-external-1.amazonaws.com/') or location.startswith('https://s3.amazonaws.com/'):
         # if we can find credentials, attach them
         session = botocore.session.get_session()
         cred = [getattr(session.get_credentials(), attr) for attr in ['access_key', 'secret_key']]

--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -106,7 +106,7 @@ def file_handler(path):
 
 def http_download(location):
     cred = None
-    if location.startswith('https://s3.amazonaws.com'):
+    if location.startswith('https://s3-external-1.amazonaws.com'):
         # if we can find credentials, attach them
         session = botocore.session.get_session()
         cred = [getattr(session.get_credentials(), attr) for attr in ['access_key', 'secret_key']]

--- a/src/main.py
+++ b/src/main.py
@@ -550,7 +550,7 @@ def expand_location(path):
         fname = os.path.basename(path)
         return "https://raw.githubusercontent.com/elifesciences/elife-article-xml/%s/articles/%s" % (sha, fname)
 
-    elif path.startswith('https://s3-external-1.amazonaws.com'):
+    elif path.startswith('https://s3-external-1.amazonaws.com/') or path.startswith('https://s3.amazonaws.com/'):
         # it's being downloaded from a bucket, no worries
         return path
 

--- a/src/main.py
+++ b/src/main.py
@@ -550,7 +550,7 @@ def expand_location(path):
         fname = os.path.basename(path)
         return "https://raw.githubusercontent.com/elifesciences/elife-article-xml/%s/articles/%s" % (sha, fname)
 
-    elif path.startswith('https://s3.amazonaws.com'):
+    elif path.startswith('https://s3-external-1.amazonaws.com'):
         # it's being downloaded from a bucket, no worries
         return path
 

--- a/src/tests/test_backfill.py
+++ b/src/tests/test_backfill.py
@@ -79,7 +79,7 @@ class One(BaseCase):
         paths = [{
             'msid': 16695,
             'version': 1,
-            'location': 'https://s3.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml',
+            'location': 'https://s3-external-1.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml',
         }]
         expected_lax_response = {
             "id": "16695",
@@ -176,12 +176,12 @@ class Two(BaseCase):
 
     def test_bootstrap_read_json_object_from_stdin(self):
         "json objects can be read from stdin as well, they must be line-delimited though"
-        jsonobj = '''{"msid":16695,"version":1,"location":"https://s3.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml"}'''
+        jsonobj = '''{"msid":16695,"version":1,"location":"https://s3-external-1.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml"}'''
         expected = [{
             'force': True,
             'token': 'pants-party',
             'version': 1,
-            'location': u'https://s3.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml',
+            'location': u'https://s3-external-1.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml',
             'action': 'ingest',
             'id': u'16695'
         }]
@@ -191,13 +191,13 @@ class Two(BaseCase):
 
     def test_bootstrap_read_multiple_json_objects_from_stdin(self):
         "json objects can be read from stdin as well, they must be line-delimited though"
-        jsonobj = '''{"msid":16695,"version":1,"location":"https://s3.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml"}
+        jsonobj = '''{"msid":16695,"version":1,"location":"https://s3-external-1.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml"}
 {"msid":1968,"version":1,"location":"no-location-stored"}'''
         expected = [{
             'force': True,
             'token': 'pants-party',
             'version': 1,
-            'location': u'https://s3.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml',
+            'location': u'https://s3-external-1.amazonaws.com/elife-publishing-expanded/16695.1/9c2cabd8-a25a-4d76-9f30-1c729755480b/elife-16695-v1.xml',
             'action': 'ingest',
             'id': u'16695'
         }]


### PR DESCRIPTION
See https://github.com/elifesciences/builder-private/pull/17 and needs to be coordinated with that. Maybe we should be backward compatible and accept both for a while?