### PR TITLE
Workaround to keep validating the kitchen sink

### DIFF
--- a/kitchen-sinks.sh
+++ b/kitchen-sinks.sh
@@ -11,7 +11,7 @@ mkdir -p kitchen-sinks
 rm -f kitchen-sinks/* kitchen-sinks.log
 for article in $kitchen_sinks; do
     echo "Kitchen sink ${article}"
-    ./scrape-article.sh src/tests/fixtures/$article > kitchen-sinks/$article.json
+    FORCED_IIIF=1 ./scrape-article.sh src/tests/fixtures/$article > kitchen-sinks/$article.json
     ./validate-json.sh kitchen-sinks/$article.json >> kitchen-sinks.log
 done
 

--- a/src/iiif.py
+++ b/src/iiif.py
@@ -2,6 +2,7 @@ import requests, requests_cache
 import logging
 import conf
 import utils
+import os
 
 LOG = logging.getLogger(__name__)
 requests_cache.install_cache(**{
@@ -40,6 +41,8 @@ def basic_info(msid, filename):
     info_data = iiif_info(msid, filename)
     width = iiif_width(info_data)
     height = iiif_height(info_data)
+    if 'FORCED_IIIF' in os.environ and int(os.environ['FORCED_IIIF']):
+        return 1, 1
     return width, height
 
 def iiif_info(msid, filename):


### PR DESCRIPTION
In this build we usually do not depend on external servers to contain test data, although we depend on production servers such as prod--iiif and the real, production of Glencoe.
However since we force the IIIF images to be existing, we would need an IIIF server where the bot has ingested the kitchen sink figure to be able to generate it. That, or to stub a dozen different calls to info.json files.

Therefore, a test setting to turn on selectively in the kicthen-sinks.sh script seems the lesser of three evils. Let's see if this makes the build green again