### PR TITLE
Slowly removing old image schema

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -340,7 +340,6 @@ def expand_uris(msid, data):
             element['uri'] = fixed
             return element
         # normal case: cdn link
-        element["filename"] = os.path.basename(element["uri"]) # basename here redundant?
         element["uri"] = cdnlink(msid, element["uri"])
         return element
     return visit(data, pred, fn)

--- a/src/main.py
+++ b/src/main.py
@@ -370,7 +370,7 @@ def fix_extensions(data):
             'version': data['snippet']['version'],
             'missing': missing
         }
-        LOG.info("encountered article with %s images with missing file extensions. assuming .jpg", len(missing), extra=context)
+        LOG.info("encountered article with %s images with missing file extensions. assuming .tif", len(missing), extra=context)
 
     return data
 

--- a/src/main.py
+++ b/src/main.py
@@ -304,12 +304,6 @@ def expand_iiif_uri(msid, element, element_type):
     element[element_type]["size"] = {"width": width, "height": height}
     element[element_type]["source"] = iiifsource(msid, element[element_type]["uri"].split('/')[-1])
 
-    # Temporarily copy some attributes to pass validation on older schema
-    if element_type == "image":
-        if not element.get("uri"):
-            element["uri"] = cdnlink(msid, element[element_type]["uri"].split('/')[-1])
-        if not element.get("alt") and element.get(element_type).get("alt") is not None:
-            element["alt"] = element[element_type]["alt"]
     return element
 
 def expand_uris(msid, data):

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -181,8 +181,8 @@ class ArticleScrape(BaseCase):
         ]
         expected = [
             # filename => https://cdn.tld/path/filename
-            {"uri": main.cdnlink(msid, "foo.bar"), "filename": "foo.bar"},
-            {"type": "image", "uri": main.cdnlink(msid, "foo.bar"), "filename": "foo.bar"},
+            {"uri": main.cdnlink(msid, "foo.bar")},
+            {"type": "image", "uri": main.cdnlink(msid, "foo.bar")},
             # www => http://www.
             {"uri": "http://www.foo.bar"},
             # doi:... => https://doi.org/...
@@ -267,7 +267,6 @@ class KitchenSink(BaseCase):
             return json.loads(json.dumps(d))
 
         expected_figure = {
-            'alt': '',
             'attribution': ['For the purpose having a example of how to tag a separate license for an item, we have indicated in the XML and display this is a\n                                        copyrighted figure; however it is not.'],
             'doi': '10.7554/eLife.00666.007',
             'id': 'fig1',
@@ -286,7 +285,6 @@ class KitchenSink(BaseCase):
             'label': 'Figure 1.',
             'title': 'Single figure: The header of an eLife article example on the HTML page. In the PDf this is represented as a single column.',
             'type': 'image',
-            'uri': 'https://publishing-cdn.elifesciences.org/00666/elife-00666-fig1.tif'
         }
 
         self.assertEqual(tod(expected_figure), tod(figure))

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -273,7 +273,6 @@ class KitchenSink(BaseCase):
             'id': 'fig1',
             'image': {
                 'alt': '',
-                'filename': 'elife-00666-fig1.tif',
                 'size': {
                     'height': 1,
                     'width': 1,
@@ -300,7 +299,6 @@ class KitchenSink(BaseCase):
             "title": "\n                                A description of the eLife editorial process.\n                            ",
             "placeholder": {
                 "alt": "",
-                "filename": "elife-00666-video1.jpg",
                 "size": {
                     "height": 1,
                     "width": 1,


### PR DESCRIPTION
- Removing alt and uri fields (These have been substituted by the ones inside the 'image' dictionary)
- Removing filename outside of misc/image type (There never was a filename here: only inside the 'source' dictionary https://github.com/elifesciences/api-raml/pull/122/files#diff-bcb896b4a098e003f412ac6257490386R1456)
- Correct comment about assumed file extension