### PR TITLE
Using cdn.elifesciences.org

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -129,7 +129,7 @@ RESPONSE_SCHEMA = json_load('response-schema.json')
 CDN1 = 'cdn.elifesciences.org/articles/%(padded-msid)s/%(fname)s'
 CDN2 = 'publishing-cdn.elifesciences.org/%(padded-msid)s/%(fname)s'
 
-DEFAULT_CDN = CDN1 if False else CDN2 # 'False' until we finish switching to a single CDN :(
+DEFAULT_CDN = CDN1
 CDNS_BY_ENV = {
     'end2end': 'end2end-' + CDN2,
     'continuumtest': 'continuumtest-' + CDN2,

--- a/src/tests/test_adaptor.py
+++ b/src/tests/test_adaptor.py
@@ -77,7 +77,7 @@ class Adapt(BaseCase):
         # this needs to be an UTF-8 XML document
         # without a proper 'Content-Type: application/xml; encoding=utf-8'
         # header being attached to the response
-        test_url = 'http://publishing-cdn.elifesciences.org/18722/elife-18722-v2.xml'
+        test_url = 'https://cdn.elifesciences.org/articles/18722/elife-18722-v2.xml'
         xml_text = adaptor.http_download(test_url)
         # this is a crappy quick regex to extract the XML tags we need
         titles_of_appendices = re.findall('<title>Appendix[^<]*</title>', xml_text)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -135,13 +135,12 @@ class ArticleScrape(BaseCase):
 
     def test_base_url(self):
         given = 1234
-        expected = 'https://publishing-cdn.elifesciences.org/01234/'
+        expected = 'https://cdn.elifesciences.org/articles/01234/'
         self.assertEqual(expected, main.base_url(given))
 
     def test_pdf_uri(self):
         given = (['research-article'], 1234, 1)
-        #expected = 'https://cdn.elifesciences.org/articles/01234/elife-01234-v1.pdf'
-        expected = 'https://publishing-cdn.elifesciences.org/01234/elife-01234-v1.pdf'
+        expected = 'https://cdn.elifesciences.org/articles/01234/elife-01234-v1.pdf'
         self.assertEqual(expected, main.pdf_uri(given))
 
     def test_pdf_uri_correction(self):


### PR DESCRIPTION
This is only for production however, because CDN1 does not exist for end2end and continuumtest. Creating it and coming back here, but at least we can try to build the corpus from the CDN1.