### PR TITLE
More aggressive cache cleaning on error

### DIFF
--- a/src/iiif.py
+++ b/src/iiif.py
@@ -69,7 +69,7 @@ def iiif_info(msid, filename):
     try:
         info_data = resp.json()
         return info_data
-    except AssertionError:
+    except:
         # clear cache, we don't want bad data hanging around
         clear_cache(msid, filename)
         raise


### PR DESCRIPTION
Not only on AssertionError. We had a recent case with 16658-v2 which had a blank response in the cache which was causing a ValueError("No JSON object could be decoded").