### PR TITLE
Human time in logs

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -8,7 +8,7 @@ ROOTLOG = logging.getLogger("")
 REQUESTS_CACHING = True
 
 _supported_keys = [
-    #'asctime',
+    'asctime',
     #'created',
     'filename',
     'funcName',
@@ -16,7 +16,7 @@ _supported_keys = [
     #'levelno',
     'lineno',
     'module',
-    'msecs',
+    #'msecs',
     'message',
     'name',
     'pathname',


### PR DESCRIPTION
From
```
{
  "msecs": 114.95590209960938,
  "message": "encountered article with 2 images with missing file extensions. assuming .tif",
  ...
}
```
to
```
  "asctime": "2017-05-24 14:19:05,866",
  "message": "encountered article with 17 images with missing file extensions. assuming .tif",
  ...
}
```