### PR TITLE
bugfix: dt obj passed to json handler causes error

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -51,7 +51,7 @@ def timeit(fn):
 def send_response(outgoing, response):
     # `response` here is the result of `mkresponse` below
     try:
-        utils.validate_response(response)
+        utils.validate(response, conf.RESPONSE_SCHEMA)
         channel = outgoing.write
     except ValidationError as err:
         # response doesn't validate. this probably means
@@ -172,7 +172,7 @@ def handler(json_request, outgoing):
     response = partial(send_response, outgoing)
 
     try:
-        request = utils.validate_request(json_request)
+        request = utils.validate(json_request, conf.REQUEST_SCHEMA)
     except ValueError as err:
         # given bad data. who knows what it was. die
         return response(mkresponse(ERROR, "request could not be parsed: %s" % json_request))

--- a/src/conf.py
+++ b/src/conf.py
@@ -1,6 +1,7 @@
 import os, json, logging
 from os.path import join
 from pythonjsonlogger import jsonlogger
+import utils
 import configparser as configparser
 
 ROOTLOG = logging.getLogger("")
@@ -48,7 +49,7 @@ class FormatterWithEncodedExtras(logging.Formatter):
             'exc_text', 'exc_info', 'msg', 'args',
         ]
         unknown_fields = {key: val for key, val in record.__dict__.items() if key not in _known_keys}
-        record.__dict__['extra'] = json.dumps(unknown_fields)
+        record.__dict__['extra'] = utils.json_dumps(unknown_fields)
         return super(FormatterWithEncodedExtras, self).format(record)
 
 _handler.setFormatter(FormatterWithEncodedExtras('%(levelname)s - %(asctime)s - %(message)s -- %(extra)s'))

--- a/src/fs_adaptor.py
+++ b/src/fs_adaptor.py
@@ -22,7 +22,7 @@ def mkreq(path, **overrides):
     }
     request.update(overrides)
     # don't ever generate an invalid request
-    utils.validate_request(request)
+    utils.validate(request, conf.REQUEST_SCHEMA)
     return request
 
 class SimpleQueue(object):

--- a/src/tests/test_fs_adaptor.py
+++ b/src/tests/test_fs_adaptor.py
@@ -23,7 +23,7 @@ class FS(BaseCase):
     def test_incoming_messages(self):
         "each message generated is a valid request"
         inst = fs_adaptor.IncomingQueue(self.ingest_dir, 'ingest')
-        map(utils.validate_request, list(inst)) # raises ValidationException if invalid
+        map(lambda req: utils.validate(req, conf.REQUEST_SCHEMA), list(inst)) # raises ValidationException if invalid
 
     def test_fs_incoming_never_generates_invalid_requests(self):
         "invalid requests never generate a message"

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,7 +6,7 @@ import json
 import jsonschema
 from jsonschema import validate as validator
 from jsonschema import ValidationError
-import conf
+# import conf # don't do this, conf.py depends on utils.py
 
 import logging
 LOG = logging.getLogger(__name__)
@@ -96,14 +96,6 @@ def validate(struct, schema):
         # your json is incorrect
         LOG.error("struct failed to validate against schema: %s" % err.message)
         raise
-
-def validate_request(request):
-    "validates incoming request"
-    return validate(request, conf.REQUEST_SCHEMA)
-
-def validate_response(response):
-    "validates outgoing response"
-    return validate(response, conf.RESPONSE_SCHEMA)
 
 def json_dumps(obj, **kwargs):
     "drop-in for json.dumps that handles datetime objects."


### PR DESCRIPTION
* removes the dependency on utils.py -> conf.py 
* removes some unnecessary boilerplate code 
* fixes an issue with some one sending a dt obj to the log as an `extra` param. possibly in `mkresponse`, but there are several places it may happen