### PR TITLE
No maximum version

### DIFF
--- a/schema/request-schema.json
+++ b/schema/request-schema.json
@@ -20,8 +20,7 @@
 		},
 		"version": {
 		    "type": "integer",
-		    "minimum": 1,
-		    "maximum": 9
+		    "minimum": 1
 	    },
         "force": {
             "description": "force ingest/publish action. intended for silent corrections. use with caution.",


### PR DESCRIPTION
Conceptually there are no limits to version numbers in the api-raml, so we may remove this assumption. Originally uncovered by Graham testing the 10th version of the kitchen sink article (00666).