### PR TITLE
Using /ext/tmp rather than /ext

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,12 +33,6 @@ elifeLibrary({
     }
 
     elifeMainlineOnly {    
-        //stage 'Push updated article JSON', {
-        //    sh './clone-article-json.sh /ext/tmp/elife-article-json'
-        //    sh './copy-json.sh /ext/tmp/elife-article-json'
-        //    sh 'cd /ext/tmp/elife-article-json; git push'
-        //}
-
         stage 'Master', {
             elifeGitMoveToBranch elifeGitRevision(), 'master'
         }

--- a/backfill.sh
+++ b/backfill.sh
@@ -30,9 +30,9 @@ errcho(){ >&2 echo $@; }
 
 prjdir=$(pwd) # bot-lax project, where this script lives
 tmpdir=/tmp # where we do our work
-if [ -e /ext ]; then
+if [ -e /ext/tmp ]; then
     # an external store has been mounted. do our work there.
-    tmpdir=/ext
+    tmpdir=/ext/tmp
 fi
 mustexist "$tmpdir"
 
@@ -47,7 +47,7 @@ if [ ! -z "$@" ]; then
 fi
 
 # ll: /tmp/run-2017-01-31-23-59-59 
-# or: /ext/run-2017-01-31-23-59-59
+# or: /ext/tmp/run-2017-01-31-23-59-59
 runpath="$tmpdir/$runpath" 
 
 # where to find lax


### PR DESCRIPTION
/ext has some permissions problem, it's owned by root. /ext/tmp is the standard from builder-base-formula now, owned by `elife:elife`.