### PR TITLE
Exponential backoff in external calls

### DIFF
--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -1,4 +1,5 @@
 from base import BaseCase
+from mock import patch, call
 import utils
 from datetime import datetime
 
@@ -65,3 +66,21 @@ class Utils(BaseCase):
         func(sideeffect) # call once
         self.assertRaises(ValueError, fn, sideeffect) # call again
         self.assertEqual(func(sideeffect), True) # call a final time
+
+    @patch('time.sleep')
+    def test_call_n_times_with_backoff(self, mock_sleep):
+        fn = self._fails_several_times(3)
+        func = utils.call_n_times(fn, [ValueError], num_attempts=10, initial_waiting_time=1)
+        self.assertEqual(func(), 'result')
+        self.assertEqual(mock_sleep.mock_calls, [call(1), call(2), call(4)])
+
+    def _fails_several_times(self, times):
+        total = [0]
+
+        def fn():
+            if total[0] == times:
+                return 'result'
+            else:
+                total[0] = total[0] + 1
+                raise ValueError('KABOOOM')
+        return fn

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,7 @@ import sqlite3
 import requests
 import os, copy
 import subprocess
+import time
 import json
 import jsonschema
 from jsonschema import validate as validator
@@ -153,21 +154,39 @@ def partial_match(pattern, actual):
 #
 #
 
-def call_n_times(fn, protect_from, num_attempts=3):
-    "if after calling `num_attempts` it fails to return a value, it will return None"
+def call_n_times(fn, protect_from, num_attempts=3, initial_waiting_time=0):
+    """if after calling `num_attempts` it fails to return a value, it will return None
+
+    Uses exponential backoff not to overload the target, if initial_waiting_time is specified"""
     def wrap(*args, **kwargs):
+        waiting_time = initial_waiting_time
         for i in xrange(0, num_attempts):
             try:
                 return fn(*args, **kwargs)
             except BaseException as err:
                 if type(err) in protect_from:
                     LOG.error("caught error: %s" % err)
+                    if waiting_time:
+                        time.sleep(waiting_time)
+                        waiting_time = waiting_time * 2
                     continue
                 raise
     return wrap
 
+class RemoteResponseTemporaryError(RuntimeError):
+    pass
+
 def requests_get(*args, **kwargs):
-    return call_n_times(requests.get, [sqlite3.OperationalError])(*args, **kwargs)
+    def target(*args, **kwargs):
+        response = requests.get(*args, **kwargs)
+        if response.status_code >= 500:
+            raise RemoteResponseTemporaryError("Status code was %s" % response.status_code)
+        return response
+    return call_n_times(
+        target,
+        [sqlite3.OperationalError, RemoteResponseTemporaryError],
+        initial_waiting_time=1
+    )(*args, **kwargs)
 
 #
 #


### PR DESCRIPTION
requests_get targets IIIF servers and Glencoe. To avoid overloading the former with requests in case of timeouts, we introduce a backoff where the time to wait doubles for every failure