### PR TITLE
feature: double publications now get a pass

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -27,7 +27,6 @@ _handler.setLevel(logging.DEBUG)
 _handler.setFormatter(conf._formatter)
 LOG.addHandler(_handler)
 
-
 from time import time
 from functools import wraps
 
@@ -166,7 +165,7 @@ def mkresponse(status, message, request={}, **kwargs):
     packet.update(request)
 
     # merge in any explicit overrides
-    packet.update(kwargs) # problem happens here,
+    packet.update(kwargs)
 
     # more response wrangling
     packet = renkeys(packet, [
@@ -189,9 +188,13 @@ def mkresponse(status, message, request={}, **kwargs):
     }
     LOG.log(levels[packet["status"]], "%s response", packet['status'], extra=context)
 
-    # final wrangle. success messages are None
+    # success messages are None
     if not packet['message']:
         del packet['message']
+
+    # double-publications are successful
+    if kwargs.get('code') == 'already-published':
+        packet['status'] = PUBLISHED
 
     return packet
 

--- a/src/tests/test_adaptor.py
+++ b/src/tests/test_adaptor.py
@@ -1,7 +1,7 @@
 import re
 from os.path import join
 import base
-import adaptor as adapt, fs_adaptor, conf
+import adaptor as adapt, fs_adaptor, conf, utils
 import adaptor
 import unittest
 from mock import patch
@@ -133,3 +133,22 @@ class Main(base.BaseCase):
             with patch('fs_adaptor.OutgoingQueue.write') as mock:
                 adapt.main(*argstr.split())
                 mock.assert_called()
+
+class DoublePubGood(base.BaseCase):
+    def test_already_published_response_means_aok(self):
+        "bot-lax coerces already-published error responses to successful 'published' responses"
+        lax_resp = {
+            'status': conf.ERROR,
+            'message': 'mock',
+            'token': 'a',
+            'id': 'b',
+
+            'code': 'already-published'
+        }
+
+        # coercion happens
+        resp = adapt.mkresponse(**lax_resp)
+        self.assertEqual(resp['status'], conf.PUBLISHED)
+
+        # coercion doesn't result in an invalid response
+        utils.validate(resp, conf.RESPONSE_SCHEMA)


### PR DESCRIPTION
'already-published' error responses are coerced to 'published' responses