### PR TITLE
umask for creating log files with correct permissions

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -6,6 +6,7 @@ import utils
 import configparser as configparser
 import yaml
 
+os.umask(int('002', 8))
 SRC_DIR = os.path.dirname(inspect.getfile(inspect.currentframe())) # ll: /path/to/adaptor/src/
 PROJECT_DIR = os.path.dirname(SRC_DIR)  # ll: /path/to/adaptor/
 


### PR DESCRIPTION
Files created by `www-data` or `elife` must have 664 permissions rather
than the default 644. That leaves the files writable readable by the
whole group, which includes the other user.