### PR TITLE
backfill-single now uses latest article-xml like regular backfill

### DIFF
--- a/backfill-single.sh
+++ b/backfill-single.sh
@@ -7,6 +7,17 @@ if [ "$#" != 3 ]; then
     exit 1
 fi
 
+# we ingest from the latest on the master branch
+prjdir=$(pwd) # bot-lax project, where this script lives
+xmlrepodir="$prjdir/article-xml/articles"
+(
+    . download-elife-xml.sh
+    cd $xmlrepodir
+    git reset --hard
+    git checkout master
+    git pull
+)
+
 msid="$1"
 version="$2"
 location="$3"


### PR DESCRIPTION
this is actually slightly more interesting than it first looks because we pin the article-xml repo.

do we need to continue pinning the article-xml repo given that we ignore it for backfill and backfill-single? if not there is a good amount of bash code we can remove.