### PR TITLE
Move --serial down in the command-specific options

### DIFF
--- a/src/adaptor.py
+++ b/src/adaptor.py
@@ -85,9 +85,9 @@ def call_lax(action, id, version, token, article_json=None, force=False, dry_run
     cmd = [
         find_lax(), # /srv/lax/manage.sh
         "--skip-install",
-        "--serial",
         "ingest",
         "--" + action, # ll: --ingest+publish
+        "--serial",
         "--id", str(id),
         "--version", str(version),
     ]


### PR DESCRIPTION
https://github.com/elifesciences/bot-lax-adaptor/pull/396 fails in end2end