### PR TITLE
PI-626 Allow logging from utils

### DIFF
--- a/src/dateutils.py
+++ b/src/dateutils.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from dateutil import parser
+import json
+import pytz
+from rfc3339 import rfc3339
+
+def todt(val):
+    "turn almost any formatted datetime string into a UTC datetime object"
+    if val is None:
+        return None
+    dt = val
+    if not isinstance(dt, datetime):
+        dt = parser.parse(val, fuzzy=False)
+    dt.replace(microsecond=0) # not useful, never been useful, will never be useful.
+
+    if not dt.tzinfo:
+        # no timezone (naive), assume UTC and make it explicit
+        return pytz.utc.localize(dt)
+
+    else:
+        # ensure tz is UTC
+        if dt.tzinfo != pytz.utc:
+            return dt.astimezone(pytz.utc)
+    return dt
+
+def ymdhms(dt):
+    "returns an rfc3339 representation of a datetime object"
+    if dt:
+        dt = todt(dt) # convert to utc, etc
+        return rfc3339(dt, utc=True)
+
+def json_dumps(obj, **kwargs):
+    "drop-in for json.dumps that handles datetime objects."
+    def datetime_handler(obj):
+        if hasattr(obj, 'isoformat'):
+            return ymdhms(obj)
+        else:
+            raise TypeError('Object of type %s with value of %s is not JSON serializable' % (type(obj), repr(obj)))
+    return json.dumps(obj, default=datetime_handler, **kwargs)

--- a/src/log.py
+++ b/src/log.py
@@ -1,0 +1,57 @@
+import logging
+from pythonjsonlogger import jsonlogger
+import dateutils
+
+def setup_root_logger():
+    root_logger = logging.getLogger("")
+
+    # output to stderr
+    _handler = logging.StreamHandler()
+    _handler.setLevel(logging.INFO)
+
+    class FormatterWithEncodedExtras(logging.Formatter):
+        def format(self, record):
+            # exclude all known keys in Record
+            # bundle the remainder into an 'extra' field,
+            # bypassing attempt to make Record read-only
+            _known_keys = [
+                'asctime', 'created', 'filename', 'funcName', 'levelname', 'levelno', 'lineno',
+                'module', 'msecs', 'message', 'name', 'pathname', 'process', 'processName',
+                'relativeCreated', 'thread', 'threadName',
+                # non-formatting fields present in __dict__
+                'exc_text', 'exc_info', 'msg', 'args',
+            ]
+            unknown_fields = {key: val for key, val in record.__dict__.items() if key not in _known_keys}
+            record.__dict__['extra'] = dateutils.json_dumps(unknown_fields)
+            return super(FormatterWithEncodedExtras, self).format(record)
+
+    _handler.setFormatter(FormatterWithEncodedExtras('%(levelname)s - %(asctime)s - %(message)s -- %(extra)s'))
+
+    root_logger.addHandler(_handler)
+    root_logger.setLevel(logging.DEBUG)
+
+def json_formatter():
+    _supported_keys = [
+        'asctime',
+        #'created',
+        'filename',
+        'funcName',
+        'levelname',
+        #'levelno',
+        'lineno',
+        'module',
+        #'msecs',
+        'message',
+        'name',
+        'pathname',
+        #'process',
+        #'processName',
+        #'relativeCreated',
+        #'thread',
+        #'threadName'
+    ]
+
+    # optional json logging if you need it
+    _log_format = ['%({0:s})'.format(i) for i in _supported_keys]
+    _log_format = ' '.join(_log_format)
+    return jsonlogger.JsonFormatter(_log_format)

--- a/src/log.py
+++ b/src/log.py
@@ -6,8 +6,8 @@ def setup_root_logger():
     root_logger = logging.getLogger("")
 
     # output to stderr
-    _handler = logging.StreamHandler()
-    _handler.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
 
     class FormatterWithEncodedExtras(logging.Formatter):
         def format(self, record):
@@ -25,13 +25,13 @@ def setup_root_logger():
             record.__dict__['extra'] = dateutils.json_dumps(unknown_fields)
             return super(FormatterWithEncodedExtras, self).format(record)
 
-    _handler.setFormatter(FormatterWithEncodedExtras('%(levelname)s - %(asctime)s - %(message)s -- %(extra)s'))
+    handler.setFormatter(FormatterWithEncodedExtras('%(levelname)s - %(asctime)s - %(message)s -- %(extra)s'))
 
-    root_logger.addHandler(_handler)
+    root_logger.addHandler(handler)
     root_logger.setLevel(logging.DEBUG)
 
 def json_formatter():
-    _supported_keys = [
+    supported_keys = [
         'asctime',
         #'created',
         'filename',
@@ -52,6 +52,6 @@ def json_formatter():
     ]
 
     # optional json logging if you need it
-    _log_format = ['%({0:s})'.format(i) for i in _supported_keys]
-    _log_format = ' '.join(_log_format)
-    return jsonlogger.JsonFormatter(_log_format)
+    log_format = ['%({0:s})'.format(i) for i in supported_keys]
+    log_format = ' '.join(log_format)
+    return jsonlogger.JsonFormatter(log_format)


### PR DESCRIPTION
There is a mutual dependency between the `conf` and `utils` modules, currently with the first including the second. Since the root logger is set up in the first,  can't really log anything as the `LOG` object is setup too soon and doesn't write the log calls.

This PR extracts a `log` module that can be included by in  to break the mutual dependency. As a consequence, some functions have to be moved out of `utils` so that dependencies become like:
- `conf` -> `log`
- `conf` -> `utils`
- `log` -> `dateutils` (new module)
- `utils` -> `dateutils`