### PR TITLE
Manually provide commit status for develop branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,7 @@ elifeLibrary({
 
     elifeMainlineOnly {    
         stage 'Master', {
+            elifeGithubCommitStatus elifeGitRevision(), 'success', 'continuous-integration/jenkins/pr-head', 'Alfred automated merge to master'
             elifeGitMoveToBranch elifeGitRevision(), 'master'
         }
 


### PR DESCRIPTION
Not sure whether we weren't protecting the `master` branch before, or
whether Jenkins was sending the commit status automatically.