### PR TITLE
removed reference to elife-hosted fork of connexion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 autopep8==1.3.2
 boto3==1.4.4
+connexion==1.2
 coverage==4.1
 et3==1.5
 git+https://github.com/elifesciences/elife-tools.git@66df93af6512b0aa85a64357492d187bc0ecb569#egg=elifetools
 Flask==0.12.2
 Flask-Testing==0.6.2
+flex==6.10.0
 future==0.16.0
 green==2.9.0
 isbnlib==3.7.2
@@ -24,7 +26,3 @@ requests-cache==0.4.13
 rfc3339==5.2
 strict-rfc3339==0.7
 uWSGI==2.0.15
-
-connexion==1.2
-#git+https://github.com/elifesciences/connexion.git@995ebab9a5731c664434f0fc8f8fd1bc1acfa5b0#egg=connexion
-flex==6.10.0


### PR DESCRIPTION
doesn't look like it's being used and I want to delete https://github.com/elifesciences/connexion