### PR TITLE
PI-644 Remove PDF link from retractions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -164,7 +164,7 @@ def pdf_uri(triple):
     older articles that should have a pdf, don't. this function doesn't
     concern itself with those latter exceptions."""
     content_type, msid, version = triple
-    if content_type and any(lmap(lambda type: type in ['Correction'], content_type)):
+    if content_type and any(lmap(lambda type: type in ['Correction', 'Retraction'], content_type)):
         return EXCLUDE_ME
     filename = "elife-%s-v%s.pdf" % (utils.pad_msid(msid), version) # ll: elife-09560-v1.pdf
     return cdnlink(msid, filename)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -201,6 +201,11 @@ class ArticleScrape(base.BaseCase):
         expected = main.EXCLUDE_ME
         self.assertEqual(expected, main.pdf_uri(given))
 
+    def test_pdf_uri_retraction(self):
+        given = (['Retraction'], 1234, 1)
+        expected = main.EXCLUDE_ME
+        self.assertEqual(expected, main.pdf_uri(given))
+
     def test_pdf_uri_bad(self):
         cases = [
             ("asdf", "asdf", "asdf"),


### PR DESCRIPTION
Retractions seem not to have PDFs, in the same way as corrections.

Perhaps this could be reimplemented by looking in the XML for an
indication of whether the PDF exists or not. This is a patch to fix a soon-to-be published article.

Also tested by generating the JSON locally.