### PR TITLE
truncates length of message to be sent bia SQS to first 256k characters.

### DIFF
--- a/src/sqs_adaptor.py
+++ b/src/sqs_adaptor.py
@@ -24,8 +24,11 @@ def poll(queue_obj):
                 WaitTimeSeconds=20 # maximum setting for long polling
             )
         message = messages[0]
-        yield message.body
-        message.delete()
+        try:
+            yield message.body
+        finally:
+            # message is always deleted, even if this leads to no response to sent messages
+            message.delete()
 
 class IncomingQueue(object):
     def __init__(self, queue_name, flag=None):
@@ -57,10 +60,6 @@ class OutgoingQueue(object):
 
     def write(self, string):
         "called when given a validated response"
-        # totally naive. unicode check probably needed
-        if len(string) >= 256000:
-            LOG.error("message to be sent is very large and will be truncated to 256KB")
-        string = string[:256000]
         self.queue.send_message(MessageBody=string)
 
     def error(self, string):

--- a/src/sqs_adaptor.py
+++ b/src/sqs_adaptor.py
@@ -57,6 +57,10 @@ class OutgoingQueue(object):
 
     def write(self, string):
         "called when given a validated response"
+        # totally naive. unicode check probably needed
+        if len(string) >= 256000:
+            LOG.error("message to be sent is very large and will be truncated to 256KB")
+        string = string[:256000]
         self.queue.send_message(MessageBody=string)
 
     def error(self, string):

--- a/src/sqs_adaptor.py
+++ b/src/sqs_adaptor.py
@@ -51,8 +51,10 @@ class IncomingQueue(object):
 
             LOG.debug("processing message")
             message = messages[0]
-            yield message.body
-            message.delete()
+            try:
+                yield message.body
+            finally:
+                message.delete()
 
 class OutgoingQueue(object):
     def __init__(self, queue_name):

--- a/src/sqs_adaptor.py
+++ b/src/sqs_adaptor.py
@@ -54,6 +54,7 @@ class IncomingQueue(object):
             try:
                 yield message.body
             finally:
+                # message is always deleted, even if this leads to no response to sent messages
                 message.delete()
 
 class OutgoingQueue(object):

--- a/src/tests/test_adaptor.py
+++ b/src/tests/test_adaptor.py
@@ -75,7 +75,6 @@ class Logic(base.BaseCase):
         titles_of_appendices = re.findall('<title>Appendix[^<]*</title>', xml_text)
         self.assertIn(u'<title>Appendix\xa01</title>', titles_of_appendices)
 
-
 class Main(base.BaseCase):
     def setUp(self):
         self.ingest_dir = join(self.fixtures_dir, 'dir-ingest-small', 'v1')

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,8 +7,7 @@ import subprocess
 import time
 from collections import OrderedDict
 import jsonschema
-from jsonschema import validate as validator
-from jsonschema import ValidationError
+from jsonschema import validate as validator, ValidationError
 from past.builtins import basestring
 import requests
 import requests_cache
@@ -55,11 +54,11 @@ def video_msid(msid):
         return pad_msid(str(msid)[-5:])
     return msid
 
-def ensure(assertion, msg, *args):
+def ensure(assertion, msg, exception_class=AssertionError):
     """intended as a convenient replacement for `assert` statements that
     get compiled away with -O flags"""
     if not assertion:
-        raise AssertionError(msg % args)
+        raise exception_class(msg)
 
 def writable_dir(path):
     ensure(os.path.exists(path), "path doesn't exist: %r" % path)
@@ -106,7 +105,7 @@ def first(x):
 
 def validate(struct, schema):
     # if given a string, assume it's json and try to load it
-    # if given a data, assume it's serializable, dump it and load it
+    # else, assume it's serializable, dump it and load it
     try:
         if isinstance(struct, basestring):
             struct = json.loads(struct)


### PR DESCRIPTION
ticket: https://elifesciences.atlassian.net/browse/ELPP-3740

* sqs message is *always* deleted, preventing the infinite loop case
* further validation of response to ensure size is something SQS can manage