### PR TITLE
Feature: api relax fname requirement

### DIFF
--- a/schema/api.yaml
+++ b/schema/api.yaml
@@ -78,7 +78,17 @@ paths:
           uniqueItems: true
           items:
             type: string
-            
+        - name: id
+          description: 'the article ID, aka "manuscript id" or "msid"'
+          type: number
+          in: query
+          required: true
+        - name: version
+          description: 'the article version'
+          type: number
+          in: query
+          required: true
+
         #- name: override
         #  in: body
         #  description: "a pipe separated key and value, for example: title|new title"

--- a/src/api.py
+++ b/src/api.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 #
 
 def validate_schema():
-    "validates the api scheme"
+    "validates the api schema"
     path = join(conf.PROJECT_DIR, 'schema', 'api.yaml')
     spec = flex.load(path)
     validate(spec)
@@ -103,6 +103,8 @@ def get_article_json(filename):
 
 def post_xml():
     "upload jats xml, generate xml, validate, send to lax as a dry run"
+    LOG.info(request.__dict__)
+
     http_ensure('xml' in request.files, "xml file required", 404)
 
     try:
@@ -176,7 +178,9 @@ def post_xml():
 
     # send to lax
     try:
-        msid, version = utils.version_from_path(filename)
+        #msid, version = utils.version_from_path(filename)
+        msid = request.args['id']
+        version = request.args['version']
         token = str(uuid.uuid4())
         args = {
             # the *most* important parameter. don't modify lax.

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -70,7 +70,7 @@ class Two(FlaskTestCase):
         }
 
         with patch('adaptor.call_lax', return_value=expected_lax_resp):
-            resp = self.client.post('/xml', **{
+            resp = self.client.post('/xml?id=16695&version=1', **{
                 'buffered': True,
                 'content_type': 'multipart/form-data',
                 'data': {

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -45,7 +45,7 @@ class FlaskTestCase(TestCase):
     render_templates = False
 
     def create_app(self):
-        self.temp_dir = tempfile.mkdtemp(suffix='bot-lax-api-test')
+        self.temp_dir = tempfile.mkdtemp(suffix='-bot-lax-api-test')
         cxx = api.create_app({
             'DEBUG': True,
             'UPLOAD_FOLDER': self.temp_dir
@@ -128,7 +128,7 @@ class Two(FlaskTestCase):
             'ajson': expected_ajson,
         }
         with patch('adaptor.call_lax', return_value=mock_lax_resp):
-            resp = self.client.post('/xml', **{
+            resp = self.client.post('/xml?id=16695&version=1', **{
                 'buffered': True,
                 'content_type': 'multipart/form-data',
                 'data': payload,
@@ -149,7 +149,7 @@ class Two(FlaskTestCase):
         xml_fixture = join(self.fixtures_dir, xml_fname)
 
         bad_ext = '.pants'
-        resp = self.client.post('/xml', **{
+        resp = self.client.post('/xml?id=16695&version=1', **{
             'buffered': True,
             'content_type': 'multipart/form-data',
             'data': {
@@ -177,7 +177,7 @@ class Two(FlaskTestCase):
         # msid doesn't match
         # filename doesn't match pattern 'elife-msid-vN.xml'
         bad_path = '/var/www/html/_default/cms/cms-0.9.40-alpha/ecs_includes/packageCreator/19942-v1.xml'
-        resp = self.client.post('/xml', **{
+        resp = self.client.post('/xml?id=16695&version=1', **{
             'buffered': True,
             'content_type': 'multipart/form-data',
             'data': {
@@ -203,7 +203,7 @@ class Two(FlaskTestCase):
         xml_fixture = join(self.fixtures_dir, xml_fname)
 
         with patch('main.main', side_effect=AssertionError('meow')):
-            resp = self.client.post('/xml', **{
+            resp = self.client.post('/xml?id=16695&version=1', **{
                 'buffered': True,
                 'content_type': 'multipart/form-data',
                 'data': {
@@ -236,7 +236,7 @@ class Two(FlaskTestCase):
 
         with open(xml_fixture, 'rb') as fh:
             for override in cases:
-                resp = self.client.post('/xml', **{
+                resp = self.client.post('/xml?id=16695&version=1', **{
                     'buffered': True,
                     'content_type': 'multipart/form-data',
                     'data': { # culprit lies in the payload here somewhere
@@ -265,7 +265,7 @@ class Two(FlaskTestCase):
         xml_fixture = join(self.fixtures_dir, xml_fname)
 
         with patch('adaptor.call_lax', side_effect=AssertionError("test shouldn't make it this far!")):
-            resp = self.client.post('/xml', **{
+            resp = self.client.post('/xml?id=666&version=1', **{
                 'buffered': True,
                 'content_type': 'multipart/form-data',
                 'data': {
@@ -317,7 +317,7 @@ class Two(FlaskTestCase):
             u'datetime': u'2017-07-04T07:37:24Z'
         }
         with patch('adaptor.call_lax', return_value=mock_lax_resp):
-            resp = self.client.post('/xml', **{
+            resp = self.client.post('/xml?id=16695&version=1', **{
                 'buffered': True,
                 'content_type': 'multipart/form-data',
                 'data': payload,
@@ -357,7 +357,7 @@ class Two(FlaskTestCase):
             u'datetime': u'2017-07-04T07:37:24Z'
         }
         with patch('adaptor.call_lax', return_value=mock_lax_resp):
-            resp = self.client.post('/xml', **{
+            resp = self.client.post('/xml?id=16695&version=1', **{
                 'buffered': True,
                 'content_type': 'multipart/form-data',
                 'data': payload,
@@ -383,7 +383,7 @@ class Two(FlaskTestCase):
             #'trace': '...' # super long, can't predict, especially when mocking
         }
         with patch('glencoe.validate_gc_data', side_effect=AssertionError(err_message)):
-            resp = self.client.post('/xml', **{
+            resp = self.client.post('/xml?id=666&version=1', **{
                 'buffered': True,
                 'content_type': 'multipart/form-data',
                 'data': {
@@ -412,7 +412,7 @@ class Two(FlaskTestCase):
             # also, don't call iiif
             no_iiif_info = {}
             with patch('iiif.iiif_info', return_value=no_iiif_info): # another?
-                resp = self.client.post('/xml', **{
+                resp = self.client.post('/xml?id=24271&version=1', **{
                     'buffered': True,
                     'content_type': 'multipart/form-data',
                     'data': {
@@ -421,6 +421,7 @@ class Two(FlaskTestCase):
                 })
 
         # ensure ajson validated
+        print(self.temp_dir, ' ', xml_fname)
         expected_ajson_path = join(self.temp_dir, xml_fname) + '.json'
         success, _ = validate.main(open(expected_ajson_path, 'r', encoding='utf-8'))
         self.assertTrue(success)


### PR DESCRIPTION
ticket: https://github.com/elifesciences/jira-import/issues/4307

It is inconvenient for third parties to use the elife filename format (elife-{msid}-v{version}.xml) when sending article xml to the bot-lax api.

This change adds the ability to supply the msid and version as query parameters to the `/xml` endpoint. The versions need not match, but the msid should.