### PR TITLE
introduces 'api.pre-validate' flag that allows bot-lax article-json validation to be skipped

### DIFF
--- a/elife.cfg
+++ b/elife.cfg
@@ -13,5 +13,8 @@ env_for_cdn:
 cdn_iiif: https://iiif.elifesciences.org/lax/
 iiif: https://prod--iiif.elifesciences.org/lax/
 
+[api]
+pre_validate: True
+
 [lax]
 location: /srv/lax/

--- a/src/api.py
+++ b/src/api.py
@@ -3,10 +3,8 @@ import logging
 import os
 from os.path import join
 from io import StringIO
-
 import traceback
 import uuid
-
 import connexion
 from connexion.resolver import RestyResolver
 import flask
@@ -15,7 +13,6 @@ import flex
 from flex.core import validate
 import jsonschema
 from werkzeug.exceptions import HTTPException
-
 import adaptor, conf, utils, main as scraper, validate as ajson_validate
 from utils import lmap, lfilter, first
 
@@ -115,7 +112,7 @@ def post_xml():
             'code': conf.BAD_OVERRIDES,
             'message': 'an error occurred attempting to parse your given overrides.',
             'trace': sio.getvalue()
-        }
+        } # shouldn't this be a 400?
 
     # upload
     try:
@@ -124,6 +121,7 @@ def post_xml():
         http_ensure(os.path.splitext(filename)[1] == '.xml', "file doesn't look like xml")
         path = join(upload_folder(), filename)
         xml.save(path)
+
     except Exception as err:
         sio = StringIO()
         traceback.print_exc(file=sio)
@@ -132,7 +130,7 @@ def post_xml():
             'code': conf.BAD_UPLOAD,
             'message': 'an error occured uploading the article xml to be processed',
             'trace': sio.getvalue(),
-        }, 400 # everything is always the client's fault.
+        }, 400 # shouldn't this be a 500?
 
     # generate
     try:
@@ -143,6 +141,7 @@ def post_xml():
         json_filename = filename + '.json'
         json_path = join(upload_folder(), json_filename)
         open(json_path, 'w').write(article_json)
+
     except Exception as err:
         sio = StringIO()
         traceback.print_exc(file=sio)
@@ -155,7 +154,7 @@ def post_xml():
 
     # validate
     try:
-        ajson_validate.main(open(json_path, 'r'))
+        conf.API_PRE_VALIDATE and ajson_validate.main(open(json_path, 'r'))
 
     except jsonschema.ValidationError as err:
         return {
@@ -164,6 +163,7 @@ def post_xml():
             'message': 'the generated article-json failed validation, see trace for details.',
             'trace': str(err), # todo: any good?
         }, 400
+
     except Exception as err:
         sio = StringIO()
         traceback.print_exc(file=sio)
@@ -172,7 +172,7 @@ def post_xml():
             'code': conf.ERROR_VALIDATING,
             'message': 'an error occurred attempting to validate the generated article-json',
             'trace': sio.getvalue()
-        }, 400
+        }, 400 # TODO: shouldn't this be a 500?
 
     # send to lax
     try:
@@ -221,7 +221,7 @@ def post_xml():
             'code': conf.ERROR_COMMUNICATING,
             'message': "lax responded with something that couldn't be decoded",
             'trace': sio.getvalue(),
-        }, 400
+        }, 400 # TODO: shouldn't this be a 500?
 
 def create_app(cfg_overrides=None):
     app = connexion.App(__name__, specification_dir=join(conf.PROJECT_DIR, 'schema'))

--- a/src/conf.py
+++ b/src/conf.py
@@ -105,6 +105,9 @@ if ENV != DEV:
     API_UPLOAD_FOLDER = cfg('general.upload_path', API_UPLOAD_FOLDER)
 utils.writable_dir(API_UPLOAD_FOLDER)
 
+# pre-validate means 'validate with placeholders in bot-lax before proper validating on lax'
+API_PRE_VALIDATE = cfg('api.pre_validate', True)
+
 CDN1 = cfg('general.cdn1') + '%(padded-msid)s/%(fname)s'
 
 if cfg('general.env_for_cdn'):


### PR DESCRIPTION
skipped in favour of lax doing the article-json validation. Lax has the better error messages now after all.