### PR TITLE
Portability of project and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This application:
 
     $ ./install.sh
     
-Edit the app.cfg file:
+This will create a default `app.cfg` file. You can edit the app.cfg file to set the `cache_path` value to another directory if the `.` default doesn't suit you:
 
-Set the cach_path value to a suitable directory e.g.
-
-cache_path: .
+```
+cache_path: /tmp
+```
 
 ## web interface
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This application:
 ## installation
 
     $ ./install.sh
+    
+Edit the app.cfg file:
+
+Set the cach_path value to a suitable directory e.g.
+
+cache_path: .
 
 ## web interface
 

--- a/elife.cfg
+++ b/elife.cfg
@@ -2,7 +2,7 @@
 env: dev
 #upload_path uploads
 # lax--ci needs it's own app.cfg file
-cache_path: /home/elife
+cache_path: .
 
 cdn1: cdn.elifesciences.org/articles/
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ py=${python##*/} # ll: python3.6
 if [ ! -e "venv/bin/$py" ]; then
     echo "could not find venv/bin/$py, recreating venv"
     rm -rf venv
-    $python -m venv venv
+    virtualenv --python=$python venv/
 fi
 
 source venv/bin/activate

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
-set -e
+set -e # everything must succeed.
+echo "[-] install.sh"
 
-python=$(which python3.6) # python3.6?
-py=${python##*/} # ll: python3.6
+. download-api-raml.sh
 
-# check for exact version of python3
-if [ ! -e "venv/bin/$py" ]; then
-    echo "could not find venv/bin/$py, recreating venv"
-    rm -rf venv
-    virtualenv --python=$python venv/
-fi
+. mkvenv.sh
 
 source venv/bin/activate
 
@@ -36,4 +31,4 @@ fi
 
 pip install -r requirements.txt
 
-. download-api-raml.sh
+echo "[✓] install.sh"

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-python=$(which python3.5) # python3.5?
-py=${python##*/} # ll: python3.5
+python=$(which python3.6) # python3.6?
+py=${python##*/} # ll: python3.6
 
 # check for exact version of python3
 if [ ! -e "venv/bin/$py" ]; then

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,12 @@ source venv/bin/activate
 if [ ! -e app.cfg ]; then
     echo "* no app.cfg found! using the example settings (elife.cfg) by default."
     ln -s elife.cfg app.cfg
+    if [ "$ENVIRONMENT_NAME" = "ci" ]; then
+        echo "* share cache between builds for better performance (cache_path)"
+        cp app.cfg app.cfg.ci
+        sed -i -e 's#cache_path:.*#cache_path: /home/elife#g' app.cfg.ci
+        mv app.cfg.ci app.cfg
+    fi
 fi
 
 if pip list | grep elifetools; then

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-python=/usr/bin/python3.5
+python=$(which python3.5) # python3.5?
 py=${python##*/} # ll: python3.5
 
 # check for exact version of python3


### PR DESCRIPTION
- Python 3.6 as 3.5 was giving some problems on installation of various packages
- dev-friendly default for `cache_path`
- create `virtualenv` avoiding `ensurepip` error