### PR TITLE
Feature: disable glencoe caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ elife-tools/
 src/elifetools
 /*.sqlite3
 run-*/
+.pytest_cache/
 unpub-article-xml/

--- a/elife.cfg
+++ b/elife.cfg
@@ -6,7 +6,7 @@ env: dev
 #upload_path:
 
 # path to the requests_cache sqlite database
-#cache_path: /home/elife
+cache_path: /home/elife
 
 cdn1: cdn.elifesciences.org/articles/
 

--- a/elife.cfg
+++ b/elife.cfg
@@ -1,17 +1,23 @@
 [general]
+# "ci", "end2end"
 env: dev
-#upload_path uploads
-# lax--ci needs it's own app.cfg file
-cache_path: /home/elife
+
+# api setting. where to store XML files uploaded to the service?
+#upload_path:
+
+# path to the requests_cache sqlite database
+#cache_path: /home/elife
 
 cdn1: cdn.elifesciences.org/articles/
 
-# e.g. env_for_cdn: end2end- or
-#      env_for_cdn: continuumtest-
+# "continuumtest", "end2end"
 env_for_cdn: 
 
 cdn_iiif: https://iiif.elifesciences.org/lax/
 iiif: https://prod--iiif.elifesciences.org/lax/
+
+[glencoe]
+cache_requests: True
 
 [api]
 pre_validate: True

--- a/src/conf.py
+++ b/src/conf.py
@@ -118,12 +118,16 @@ else:
 CDN_IIIF = cfg('general.cdn_iiif') + '%(padded-msid)s%%2F%(fname)s'
 IIIF = cfg('general.iiif') + '%(padded-msid)s%%2F%(fname)s/info.json'
 
-# should our http requests to external services be cached?
+# global requests_cache switch
 REQUESTS_CACHING = True
+# glencoe specific requests_cache switch
+GLENCOE_REQUESTS_CACHING = cfg('glencoe.cache_requests', True)
+
 REQUESTS_CACHE = join(CACHE_PATH, 'requests-cache')
 if sys.version_info.major == 3:
     REQUESTS_CACHE = join(CACHE_PATH, 'requests_cache')
 
+# todo: remove this, unused
 # *may* improve locked db problem
 # https://requests-cache.readthedocs.io/en/latest/api.html#backends-dbdict
 ASYNC_CACHE_WRITES = False

--- a/src/glencoe.py
+++ b/src/glencoe.py
@@ -4,8 +4,6 @@ from cache_requests import install_cache_requests
 import conf, utils
 from utils import ensure, lmap, lfilter, sortdict
 from collections import OrderedDict
-from contextlib import contextmanager
-from functools import partial
 
 LOG = logging.getLogger(__name__)
 
@@ -62,16 +60,6 @@ def validate_gc_data(gc_data):
         msg = "number of available sources less than known sources for %r. missing: %s" % \
             (v_id, ", ".join(set(known_sources) - set(available_sources)))
         ensure(len(available_sources) == len(known_sources), msg)
-
-@contextmanager
-def glencoe_caching_rules():
-    """Glencoe has special caching rules: only cache if global requests
-    caching is on AND glencoe caching is on"""
-    cache = conf.REQUESTS_CACHING and conf.GLENCOE_REQUESTS_CACHING
-    cache_name = conf.REQUESTS_CACHE
-    caching = partial(requests_cache.enabled, cache_name) if cache else requests_cache.disabled
-    with caching():
-        yield
 
 def clear_cache(msid):
     requests_cache.core.get_cache().delete_url(glencoe_url(msid))

--- a/src/utils.py
+++ b/src/utils.py
@@ -225,11 +225,18 @@ def loadobj(path):
 
 def requests_get(*args, **kwargs):
     def target(*args, **kwargs):
+        # https://2.python-requests.org/en/master/user/advanced/#prepared-requests
         request = requests.Request('GET', *args, **kwargs)
         prepared_request = request.prepare()
-        cache_key = requests_cache_create_key(prepared_request)
-        LOG.info("Requesting url %s (cache key '%s')", args[0], cache_key)
         s = requests.Session()
+
+        # if caching enabled, log the key used to cache the response
+        if hasattr(s, 'cache'): # test if requests_cache is enabled
+            cache_key = requests_cache_create_key(prepared_request)
+            LOG.info("Requesting url %s (cache key '%s')", args[0], cache_key)
+        else:
+            LOG.info("Requesting url %s", args[0])
+
         response = s.send(prepared_request)
         if response.status_code >= 500:
             raise RemoteResponseTemporaryError("Status code was %s" % response.status_code)


### PR DESCRIPTION
* adds ability to disable glencoe requests_cache response caching
* git-ignores hidden pytest dir
* ~disables `cache_path` setting with (useless) value of `/home/elife`~

- [x] blocked by https://github.com/elifesciences/lax-formula/pull/37