### PR TITLE
Feature: added ability to retry a http get on 404 response

### DIFF
--- a/src/glencoe.py
+++ b/src/glencoe.py
@@ -70,10 +70,10 @@ def metadata(msid):
     url = glencoe_url(msid)
 
     if conf.REQUESTS_CACHING and conf.GLENCOE_REQUESTS_CACHING:
-        resp = utils.requests_get(url)
+        resp = utils.requests_get(url, retry_on_404=True)
     else:
         with requests_cache.disabled():
-            resp = utils.requests_get(url)
+            resp = utils.requests_get(url, retry_on_404=True)
 
     context = {'msid': msid, 'glencoe-url': url, 'status-code': resp.status_code}
 

--- a/src/tests/test_glencoe.py
+++ b/src/tests/test_glencoe.py
@@ -1,3 +1,4 @@
+import requests
 from tests import base
 from src import glencoe
 from unittest.mock import patch
@@ -13,6 +14,25 @@ class Cmd(base.BaseCase):
         with patch('utils.requests_get') as mock:
             mock.return_value.status_code = 404
             self.assertEqual({}, glencoe.metadata(1))
+
+    def test_metadata_found_eventually(self):
+        resp = requests.Response()
+        resp._content = b'{}' # successful but empty response
+        resp.status_code = 404
+        resp.call_count = 0
+
+        def new_send(*args):
+            if resp.call_count == 2:
+                resp.status_code = 200
+            resp.call_count += 1
+            return resp
+
+        with patch('utils._requests_get_send', new=new_send):
+            with self.assertRaises(AssertionError) as ae:
+                glencoe.metadata(1)
+                # we successfully got a response after 2 404s (even though it was empty)
+                self.assertEqual(resp.call_count, 2)
+                self.assertEqual(str(ae), "glencoe returned successfully, but response is empty")
 
     def test_metadata_unhandled_response_code(self):
         "metadata logs the body of the response on an unhandled response"

--- a/src/utils.py
+++ b/src/utils.py
@@ -239,6 +239,7 @@ def requests_get(*args, **kwargs):
         # lsh@2019-09-17, introduced to retry glencoe requests returning 404 responses when, just seconds ago
         # in elife-bot, it was returning a successful response
         if response.status_code == 404 and special_args.get('retry_on_404'):
+            LOG.warn("404 response from Glencoe: %s", args[0])
             raise RemoteResponseTemporaryError("Status code was 404 and special option 'retry_on_404' is set")
 
         return response

--- a/src/utils.py
+++ b/src/utils.py
@@ -207,24 +207,14 @@ class RemoteResponsePermanentError(RuntimeError):
 def requests_cache_create_key(prepared_request):
     return requests_cache.core.get_cache().create_key(prepared_request)
 
-'''
-# works, but only good for debugging/mocking responses
-def dumpobj(obj):
-    import cPickle, time
-    from os.path import join
-    import conf
-    fname = str(int(time.time() * 1000000)) + ".pickle"
-    path = join(conf.PROJECT_DIR, fname)
-    pickler = cPickle.Pickler(open(path, 'w'))
-    pickler.dump(obj)
-    return path
-
-def loadobj(path):
-    pass
-'''
-
 def requests_get(*args, **kwargs):
     def target(*args, **kwargs):
+
+        # these arguments are *not* passed to requests.get
+        special_keys = ['retry_on_404']
+        special_args = subdict(kwargs, ['retry_on_404'])
+        kwargs = rmkeys(kwargs, special_keys, lambda *_: True)
+
         # https://2.python-requests.org/en/master/user/advanced/#prepared-requests
         request = requests.Request('GET', *args, **kwargs)
         prepared_request = request.prepare()
@@ -240,7 +230,12 @@ def requests_get(*args, **kwargs):
         response = s.send(prepared_request)
         if response.status_code >= 500:
             raise RemoteResponseTemporaryError("Status code was %s" % response.status_code)
-        #dumpobj((request, response))
+
+        # lsh@2019-09-17, introduced to retry glencoe requests returning 404 responses when, just seconds ago 
+        # in elife-bot, it was returning a successful response
+        if response.status_code == 404 and special_args.get('retry_on_404'):
+            raise RemoteResponseTemporaryError("Status code was 404 and special option 'retry_on_404' is set")
+
         return response
     num_attempts = 3
     resp = call_n_times(


### PR DESCRIPTION
This allows the request to Glencoe be made twice more if the original response is a 404 with the standard exponential backoff, starting at 1 second, then 2 then 4.

It only affects requests made by glencoe.py