### PR TITLE
Use latest article schema model when validating.

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -91,8 +91,8 @@ def load(path):
     elif path.endswith('.yaml'):
         return yaml.load(open(path, 'r'))
 
-POA_SCHEMA = load('api-raml/dist/model/article-poa.v2.json')
-VOR_SCHEMA = load('api-raml/dist/model/article-vor.v3.json')
+POA_SCHEMA = load('api-raml/dist/model/article-poa.v3.json')
+VOR_SCHEMA = load('api-raml/dist/model/article-vor.v4.json')
 
 REQUEST_SCHEMA = load('request-schema.json')
 RESPONSE_SCHEMA = load('response-schema.json')


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6222

This may solve an issue with pipeline test failures on structured abstracts.

We may not have any real structured abstracts to test this against, but if this is green and it is a suitable change, we can test against real structured abstracts after merging this as a fix.