### PR TITLE
backfill, adds script for backfilling many articles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ run-*/
 .pytest_cache/
 unpub-article-xml/
 .pytest_cache/
+backfill.txt

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This application:
 
 1. listens for messages from the [elife-bot](https://github.com/elifesciences/elife-bot)
-2. downloads xml from S3 via HTTP
-3. converts it to a partial representation of our [article-json schema](https://github.com/elifesciences/api-raml)
+2. downloads XML from S3 via HTTP
+3. converts XML to a mostly complete representation of our [article-json schema](https://github.com/elifesciences/api-raml)
 4. sends article-json to [Lax](https://github.com/elifesciences/lax) to be ingested
 
 ## installation
@@ -68,14 +68,24 @@ use of all available cores:
 
     $ ./validate-all-json.sh
 
-## listening/sending
+## backfill
 
 ### populating a Lax installation
 
-This script ties several others together and simply does: generate, validate and
-then an `ingest --force` to lax.
+This generates, validates and then performs an `ingest --force` to lax for each article in the article-xml repository.
 
     $ ./backfill.sh
+
+The generation, validation and ingest actions happen in separate steps for greater parallelism.
+
+### updating a small subset of articles in Lax
+
+This reads a list of article IDs from a file and then generates, validates and performs an `ingest --force` to lax for
+each article sequentially. It can be quite slow for a large number of articles.
+
+    $ ./backfill-many.sh
+
+## listening/sending
 
 ### receiving messages from an AWS SQS queue
 
@@ -89,7 +99,7 @@ This is quite eLife-specific but can be modified easily if you're a developer:
 
 ## Copyright & Licence
 
-Copyright 2016 eLife Sciences. Licensed under the [GPLv3](LICENCE.txt)
+Copyright 2021 eLife Sciences. Licensed under the [GPLv3](LICENCE.txt)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/backfill-many.sh
+++ b/backfill-many.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# backills *many* articles from XML on the filesystem.
+# see `backfill.sh` to backfill *all* articles from XML.
+# see `backfill-single.sh` to backfill a *single* article from XML.
+
+set -eu
+
+backfill_file=${1:-backfill.txt}
+
+# we ingest from the latest on the master branch
+prjdir=$(pwd) # bot-lax project, where this script lives
+xmlrepodir="$prjdir/article-xml/articles"
+(
+    #. download-elife-xml.sh
+    cd $xmlrepodir
+    # do this because 'download-elife-xml.sh' obeys article-xml repository pin
+    git reset --hard
+    git checkout master
+    git pull
+)
+
+source venv/bin/activate
+
+python ./src/backfill-many.py --xml-repo-dir "$xmlrepodir" --backfill-file "$backfill_file" --dry-run

--- a/backfill-many.sh
+++ b/backfill-many.sh
@@ -11,8 +11,8 @@ backfill_file=${1:-backfill.txt}
 prjdir=$(pwd) # bot-lax project, where this script lives
 xmlrepodir="$prjdir/article-xml/articles"
 (
-    #. download-elife-xml.sh
-    cd $xmlrepodir
+    . download-elife-xml.sh
+    cd "$xmlrepodir"
     # do this because 'download-elife-xml.sh' obeys article-xml repository pin
     git reset --hard
     git checkout master
@@ -21,4 +21,4 @@ xmlrepodir="$prjdir/article-xml/articles"
 
 source venv/bin/activate
 
-python ./src/backfill-many.py --xml-repo-dir "$xmlrepodir" --backfill-file "$backfill_file" --dry-run
+python ./src/backfill-many.py --xml-repo-dir "$xmlrepodir" --backfill-file "$backfill_file"

--- a/backfill-single.sh
+++ b/backfill-single.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# backills a *single* article from XML on the filesystem.
+# see `backfill-many.sh` to backfill *many* (but not *all*) articles from XML.
+# see `backfill.sh` to backfill *all* articles from XML.
+
 set -e
 
 if [ "$#" != 3 ]; then

--- a/download-elife-xml.sh
+++ b/download-elife-xml.sh
@@ -15,6 +15,7 @@ if [ ! -d article-xml ]; then
         git remote add origin https://github.com/elifesciences/elife-article-xml
         cd -
     else
+        # article-xml respository doesn't exist, create it
         git clone https://github.com/elifesciences/elife-article-xml article-xml
     fi
 fi

--- a/src/adhoc_backfill.py
+++ b/src/adhoc_backfill.py
@@ -49,6 +49,8 @@ def do_paths(paths, dry_run=False):
 # bootstrap
 #
 
+read_from_stdin = sys.stdin.readlines
+
 def main(args):
     import argparse
     parser = argparse.ArgumentParser()
@@ -61,7 +63,7 @@ def main(args):
 
     # failing that, try reading from stdin
     if not paths:
-        paths = sys.stdin.readlines()
+        paths = read_from_stdin()
         try:
             paths = lmap(json.loads, paths)
         except ValueError:

--- a/src/adhoc_backfill.py
+++ b/src/adhoc_backfill.py
@@ -4,7 +4,7 @@ adhoc_backfill.py provides support for backfilling small numbers of arbitrary ar
 it accepts a list of paths to xml files from the command line:
   ./adhoc_backfill.py /path/to/file1.xml /path/to/file2.xml
 
-or it accepts a list of json dictionaries (one per line) whose values will override the
+or it accepts a list of json dictionaries (one per line) whose values will overridden the
 default values in making a request via adaptor.py. these values can be seen in `fs_adaptor.mkreq`
 
 """
@@ -49,8 +49,6 @@ def do_paths(paths, dry_run=False):
 # bootstrap
 #
 
-read_from_stdin = sys.stdin.readlines
-
 def main(args):
     import argparse
     parser = argparse.ArgumentParser()
@@ -63,7 +61,7 @@ def main(args):
 
     # failing that, try reading from stdin
     if not paths:
-        paths = read_from_stdin()
+        paths = sys.stdin.readlines()
         try:
             paths = lmap(json.loads, paths)
         except ValueError:

--- a/src/backfill-many.py
+++ b/src/backfill-many.py
@@ -8,7 +8,7 @@ import adhoc_backfill
 
 def main(xml_repo_dir, backfill_file, dry_run):
     assert os.path.exists(xml_repo_dir), "path to XML repository doesn't exist: %s" % xml_repo_dir
-    
+
     path_list = []
     for globbed_path in open("backfill.txt", 'r').read().splitlines():
         globbed_path = os.path.join(xml_repo_dir, globbed_path)
@@ -21,7 +21,7 @@ def main(xml_repo_dir, backfill_file, dry_run):
         assert os.path.exists(path), "path does not exist: %s" % path
 
     # prompt
-        
+
     path_list = sorted(path_list, reverse=True)
     for path in path_list:
         print(path)
@@ -34,11 +34,11 @@ def main(xml_repo_dir, backfill_file, dry_run):
         return False
 
     # finally
-    
+
     adhoc_backfill.do_paths(path_list, dry_run)
 
     # examine results for failures?
-    
+
     return True
 
 if __name__ == '__main__':

--- a/src/backfill-many.py
+++ b/src/backfill-many.py
@@ -10,7 +10,7 @@ def main(xml_repo_dir, backfill_file, dry_run):
     assert os.path.exists(xml_repo_dir), "path to XML repository doesn't exist: %s" % xml_repo_dir
 
     path_list = []
-    for globbed_path in open("backfill.txt", 'r').read().splitlines():
+    for globbed_path in open(backfill_file, 'r').read().splitlines():
         globbed_path = os.path.join(xml_repo_dir, globbed_path)
         globbed_path = os.path.abspath(globbed_path)
         result = glob.glob(globbed_path)

--- a/src/backfill-many.py
+++ b/src/backfill-many.py
@@ -1,0 +1,52 @@
+# backills many articles using a simple text file of paths to XML.
+# paths may include globs.
+# all paths are verified to exist before execution.
+# see `/backfill-many.sh`
+
+import glob, os, sys
+import adhoc_backfill
+
+def main(xml_repo_dir, backfill_file, dry_run):
+    assert os.path.exists(xml_repo_dir), "path to XML repository doesn't exist: %s" % xml_repo_dir
+    
+    path_list = []
+    for globbed_path in open("backfill.txt", 'r').read().splitlines():
+        globbed_path = os.path.join(xml_repo_dir, globbed_path)
+        globbed_path = os.path.abspath(globbed_path)
+        result = glob.glob(globbed_path)
+        assert result, "failed to find/expand path: %s" % globbed_path
+        path_list.extend(result) # glob glob glob
+
+    for path in path_list:
+        assert os.path.exists(path), "path does not exist: %s" % path
+
+    # prompt
+        
+    path_list = sorted(path_list, reverse=True)
+    for path in path_list:
+        print(path)
+    print()
+    print("found %r articles to backfill" % (len(path_list),))
+    try:
+        input("any key to continue, ctrl-c to quit")
+    except KeyboardInterrupt:
+        print()
+        return False
+
+    # finally
+    
+    adhoc_backfill.do_paths(path_list, dry_run)
+
+    # examine results for failures?
+    
+    return True
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--xml-repo-dir')
+    parser.add_argument('--backfill-file')
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+    success = main(args.xml_repo_dir, args.backfill_file, args.dry_run)
+    sys.exit(0 if success else 1)

--- a/src/backfill-many.py
+++ b/src/backfill-many.py
@@ -15,7 +15,7 @@ def main(xml_repo_dir, backfill_file, dry_run):
         globbed_path = os.path.abspath(globbed_path)
         result = glob.glob(globbed_path)
         assert result, "failed to find/expand path: %s" % globbed_path
-        path_list.extend(result) # glob glob glob
+        path_list.extend(result)
 
     for path in path_list:
         assert os.path.exists(path), "path does not exist: %s" % path


### PR DESCRIPTION
backfill.sh and backfill-single.sh weren't suitable and neither was calling ./src/adhoc-backfill.sh with hundreds/thousands of paths.

using `backfill-many.sh` you add a list of manuscript IDs to the file `backfill.txt` and then run `./backfill-many.sh` with no arguments.

there will be a complete backfill coming up soon with the preferred name change. I'll need to figure out a way to do that that doesn't bring lax to it's knees.