### PR TITLE
upgrades pip, installs wheel, falling back to legacy resolver

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ echo "[-] install.sh"
 . mkvenv.sh
 
 source venv/bin/activate
+pip install pip wheel --upgrade
 
 # link the default (elife) config if no app.cfg file found
 if [ ! -e app.cfg ]; then
@@ -23,6 +24,7 @@ if pip list | grep connexion; then
     pip uninstall -y connexion
 fi
 
-pip install -r requirements.txt
+# use legacy resolver until we can port to pipenv
+pip install -r requirements.txt --use-deprecated=legacy-resolver
 
 echo "[✓] install.sh"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ et3==1.5.1
 git+https://github.com/elifesciences/elife-tools.git@31509bfc9a8b84656ed6a1e8433894c56eff0b83#egg=elifetools
 Flask==1.0.2
 Flask-Testing==0.7.1
-flex==6.13.2
+flex==6.14.1
 future==0.16.0
 isbnlib==3.9.1
 # lsh@2020-07-07: isort pinned at 4.x as 5.x breaks api


### PR DESCRIPTION
bot-lax is currently depending on it's virtualenvs that are using a pretty old version of pip.

this upgrades pip, installs wheel so we get binary downloads and tells pip to use the old resolver behaviour, just until we port the dependencies to Pipenv like the other projects.