### PR TITLE
Change preprint attribute type to event_type.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -257,7 +257,7 @@ def preprint_events(struct):
     "returns a list of 'preprint' type events from article's pub-history or `None`"
     if not struct or not isinstance(struct, list) or len(struct) == 0:
         return
-    return [event for event in struct if event.get('type') == 'preprint'] or None
+    return [event for event in struct if event.get('event_type') == 'preprint'] or None
 
 def to_preprint(preprint):
     "returns a struct that passes api-raml validation for preprint events"

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -409,7 +409,7 @@ def test_preprint_events__empty_cases():
         ([], None),
         ("", None),
         ([{}], None),
-        ([{'type': 'foo'}], None)
+        ([{'event_type': 'foo'}], None)
     ]
     for given, expected in cases:
         assert expected == main.preprint_events(given)
@@ -419,13 +419,13 @@ def test_preprint_events():
     timeobj = time.gmtime()
     cases = [
         # only type=preprint are returned
-        ([{"type": "preprint"}, {}], [{"type": "preprint"}]),
+        ([{"event_type": "preprint"}, {}], [{"event_type": "preprint"}]),
 
         # expected structs are passed through as-is
-        ([{"type": "preprint",
+        ([{"event_type": "preprint",
            "uri": "http://foo.bar",
            "date": timeobj}],
-         [{"type": "preprint",
+         [{"event_type": "preprint",
            "uri": "http://foo.bar",
            "date": timeobj}])
     ]


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6804

Change `type` to `event_type` where the preprint data is filtered from `pub_history()` when using the `elifetools` XML parser.