### PR TITLE
Dependency `elifetools` pinned to `0.32.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ python_version = "3.8"
 boto3 = "~=1.8"
 connexion = "~=2.0"
 et3 = "~=1.5"
-elifetools = "==0.31.0"
+elifetools = "==0.32.0"
 flex = "~=6.14"
 isbnlib = "~=3.9"
 # lsh@2020-07-07: isort pinned at 4.x as 5.x breaks api

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-02-17 - see update-dependencies.sh
+# file generated 2023-02-20 - see update-dependencies.sh
 astroid==2.11.7
 attrs==22.2.0
 autopep8==1.7.0
@@ -13,7 +13,7 @@ connexion==2.14.2
 coverage==4.5.4
 dataclasses==0.6
 dill==0.3.6
-elifetools==0.31.0
+elifetools==0.32.0
 et3==1.5.2
 exceptiongroup==1.1.0
 Flask==2.2.3


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-bot-lax-adaptor-update-dependency/38/display/redirect which resulted in this pull request.