### PR TITLE
Dependency `elifetools` pinned to `0.39.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.8"
 [packages]
 boto3 = "~=1.8"
 et3 = "~=1.5"
-elifetools = "==0.38.0"
+elifetools = "==0.39.0"
 isbnlib = "~=3.9"
 joblib = "~=1.2"
 # lsh@2023-07-26: pinned to 4.17, not semver, breaking changes introduced in 4.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2023-11-18 - see update-dependencies.sh
+# file generated 2023-12-05 - see update-dependencies.sh
 astroid==2.15.8
 attrs==23.1.0
 autopep8==2.0.4
@@ -9,7 +9,7 @@ certifi==2023.7.22
 charset-normalizer==3.3.0
 coverage==7.3.2
 dill==0.3.7
-elifetools==0.38.0
+elifetools==0.39.0
 et3==1.5.2
 exceptiongroup==1.1.3
 idna==3.4


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-bot-lax-adaptor-update-dependency/56/display/redirect which resulted in this pull request.