### PR TITLE
Move elifeAssessment to the VOR snippet

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -662,6 +662,7 @@ POA.update(OrderedDict([
 VOR_SNIPPET = copy.deepcopy(POA)
 VOR_SNIPPET.update(OrderedDict([
     ('impactStatement', [jats('impact_statement_json')]),
+    ('elifeAssessment', [jats('elife_assessment'), discard_if_none_or_empty]),
 ]))
 
 # a VOR contains the contents of a VOR snippet
@@ -677,7 +678,6 @@ VOR.update(OrderedDict([
     ('appendices', [appendices]),
     ('acknowledgements', [jats('acknowledgements_json')]),
     ('editorEvaluation', [jats('editor_evaluation'), discard_if_none_or_empty]),
-    ('elifeAssessment', [jats('elife_assessment'), discard_if_none_or_empty]),
     ('decisionLetter', [jats('decision_letter')]),
     ('recommendationsForAuthors', [jats('recommendations_for_authors'), discard_if_none_or_empty]),
     ('authorResponse', [jats('author_response')]),


### PR DESCRIPTION
Will be compatible with the latest `api-raml` schema for the v8 VOR article model.

Re issue https://github.com/elifesciences/issues/issues/9038