### PR TITLE
Dependency `elifetools` pinned to `0.43.0`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.8"
 [packages]
 boto3 = "~=1.8"
 et3 = "~=1.5"
-elifetools = "==0.42.0"
+elifetools = "==0.43.0"
 isbnlib = "~=3.9"
 joblib = "~=1.2"
 # lsh@2023-07-26: pinned to 4.17, not semver, breaking changes introduced in 4.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# file generated 2024-11-18 - see update-dependencies.sh
+# file generated 2025-05-09 - see update-dependencies.sh
 astroid==2.15.8
 attrs==23.2.0
 autopep8==2.3.1
@@ -9,7 +9,7 @@ certifi==2024.7.4
 charset-normalizer==3.3.2
 coverage==7.6.0
 dill==0.3.8
-elifetools==0.42.0
+elifetools==0.43.0
 et3==1.5.2
 exceptiongroup==1.2.2
 idna==3.7


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-bot-lax-adaptor-update-dependency/66/display/redirect which resulted in this pull request.