### PR TITLE
Configure info URL to use new uncached production IIIF server

### DIFF
--- a/elife.cfg
+++ b/elife.cfg
@@ -12,7 +12,7 @@ cdn1: cdn.elifesciences.org/articles/
 env_for_cdn:
 
 cdn_iiif: https://iiif.elifesciences.org/lax/
-iiif: https://prod--iiif.elifesciences.org/lax/
+iiif: https://iiif.prod.elifesciences.org/lax/
 
 [glencoe]
 cache_requests: True


### PR DESCRIPTION
https://github.com/elifesciences/issues/issues/9340

I would like to decommission prod--iiif.elifesciences.org soon to make good on cost savings / modernisation goals. It looks like this is a slightly different code path that would want to use an uncached version, so `iiif.prod.elifesciences.org` is the equivalent to `prod--iiif.elifesciences.org`