### PR TITLE
Use sent-for-peer-review date from one of two places

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -694,7 +694,7 @@ SNIPPET = OrderedDict([
         ('preprint', [jats('pub_history'), preprint_events, first, to_preprint, discard_if_none_or_empty]),
         ('received', [jats('history_date', date_type='received'), to_isoformat, discard_if_none_or_empty]),
         ('accepted', [jats('history_date', date_type='accepted'), to_isoformat, discard_if_none_or_empty]),
-        ('sent-for-peer-review', [(jats("history_date", date_type="sent-for-review"), jats("pub_history")), sent_for_peer_review_date, to_isoformat, discard_if_none_or_empty]),
+        ('sent-for-peer-review', [(jats('history_date', date_type='sent-for-review'), jats('pub_history')), sent_for_peer_review_date, to_isoformat, discard_if_none_or_empty]),
     ])),
     ('status', [jats('is_poa'), is_poa_to_status]),
     ('id', [jats('publisher_id')]),

--- a/src/main.py
+++ b/src/main.py
@@ -601,6 +601,19 @@ def non_nil_image_dimensions(ctx, data):
 
     return visit(data, pred, fix)
 
+
+def sent_for_peer_review_date(pair):
+    "use sent-for-review history date, otherwise look for one in the pub-history dates"
+    history_date, pub_history_dates = pair
+    if history_date:
+        return history_date
+    if not pub_history_dates:
+        return None
+    for ph_date in pub_history_dates:
+        if ph_date.get("event_type") == "sent-for-review":
+            return ph_date.get("date")
+
+
 DUMMY_DATE = '2099-01-01T00:00:00Z'
 
 def placeholders_for_validation(data):
@@ -681,7 +694,7 @@ SNIPPET = OrderedDict([
         ('preprint', [jats('pub_history'), preprint_events, first, to_preprint, discard_if_none_or_empty]),
         ('received', [jats('history_date', date_type='received'), to_isoformat, discard_if_none_or_empty]),
         ('accepted', [jats('history_date', date_type='accepted'), to_isoformat, discard_if_none_or_empty]),
-        ('sent-for-peer-review', [jats('history_date', date_type='sent-for-review'), to_isoformat, discard_if_none_or_empty]),
+        ('sent-for-peer-review', [(jats("history_date", date_type="sent-for-review"), jats("pub_history")), sent_for_peer_review_date, to_isoformat, discard_if_none_or_empty]),
     ])),
     ('status', [jats('is_poa'), is_poa_to_status]),
     ('id', [jats('publisher_id')]),

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -492,17 +492,40 @@ def test_modify_preprint_event_description():
     for given, expected in cases:
         assert expected == main.modify_preprint_event_description(given)
 
+
 def test_sent_for_peer_review():
-    desc = {'sent-for-peer-review': main.SNIPPET['-history']['sent-for-peer-review']}
-    desc['sent-for-peer-review'][0] = lambda v: v # patch the call to `main.jats`
+    desc = {"sent-for-peer-review": main.SNIPPET["-history"]["sent-for-peer-review"]}
+    desc["sent-for-peer-review"][0] = lambda v: v  # patch the call to `main.jats`
     cases = [
         # empty values are elided
-        (None, [{}]),
-        ("", [{}]),
+        ((None, None), [{}]),
+        (("", ""), [{}]),
 
         # time structs are handled
-        (time.struct_time((2023, 12, 31, 1, 2, 3, 4, 56, 7)),
-         [{'sent-for-peer-review': '2023-12-31T01:02:03Z'}])
+        (
+            (time.struct_time((2023, 12, 31, 1, 2, 3, 4, 56, 7)), None),
+            [{"sent-for-peer-review": "2023-12-31T01:02:03Z"}],
+        ),
+
+        # empty pub-history dates
+        (
+            (None, []),
+            [{}],
+        ),
+
+        # date taken from pub-history dates
+        (
+            (
+                None,
+                [
+                    {
+                        "event_type": "sent-for-review",
+                        "date": time.struct_time((2023, 12, 31, 1, 2, 3, 4, 56, 7)),
+                    }
+                ],
+            ),
+            [{"sent-for-peer-review": "2023-12-31T01:02:03Z"}],
+        ),
     ]
     for given, expected in cases:
         assert expected == list(et3.render.render(desc, [given]))


### PR DESCRIPTION
In future a `sent-for-review` date may be located in the dates from `<pub-history>` XML. If the date is found from the `<history>` dates continue to use it, otherwise look for one in the data parsed from `<pub-history>`.

Re issue https://github.com/elifesciences/issues/issues/9535